### PR TITLE
fix: make SavePath property read-only per JV-Link specification

### DIFF
--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -864,9 +864,7 @@ type ComJvLinkClient(?useJvGets: bool) =
             with get () = getPropertyInt "m_saveflag" <> 0
             and set value = setPropertyInt "m_saveflag" (if value then 1 else 0) |> ignore
 
-        member _.SavePath
-            with get () = getPropertyString "m_savepath"
-            and set value = setPropertyString "m_savepath" value |> ignore
+        member _.SavePath = getPropertyString "m_savepath"
 
         member _.ServiceKey
             with get () = getPropertyString "m_servicekey"

--- a/src/Xanthos/Interop/IJvLinkClient.fs
+++ b/src/Xanthos/Interop/IJvLinkClient.fs
@@ -130,9 +130,13 @@ type IJvLinkClient =
     /// <summary>Gets or sets whether downloads are persisted to disk (<c>m_saveflag</c>).</summary>
     /// <remarks>The getter returns a default value (false) if COM property access fails. Use <see cref="TryGetSaveFlag"/> for explicit error handling.</remarks>
     abstract member SaveFlag: bool with get, set
-    /// <summary>Gets or sets the save path configured within JV-Link.</summary>
-    /// <remarks>The getter returns an empty string if COM property access fails. Use <see cref="TryGetSavePath"/> for explicit error handling.</remarks>
-    abstract member SavePath: string with get, set
+    /// <summary>Gets the save path configured within JV-Link.</summary>
+    /// <remarks>
+    /// This property is read-only. Per JV-Link specification, m_savepath can only be modified
+    /// via JVSetSavePath or JVSetUIProperties methods.
+    /// The getter returns an empty string if COM property access fails. Use <see cref="TryGetSavePath"/> for explicit error handling.
+    /// </remarks>
+    abstract member SavePath: string
     /// <summary>Gets or sets the service key configured within JV-Link.</summary>
     /// <remarks>The getter returns an empty string if COM property access fails. Use <see cref="TryGetServiceKey"/> for explicit error handling.</remarks>
     abstract member ServiceKey: string with get, set

--- a/src/Xanthos/Interop/JvLinkStub.fs
+++ b/src/Xanthos/Interop/JvLinkStub.fs
@@ -301,9 +301,7 @@ type JvLinkStub(responses: seq<Result<JvReadOutcome, ComError>>, ?totalSize: int
             and set value = saveFlag <- value
 
         /// <inheritdoc />
-        member _.SavePath
-            with get () = savePath
-            and set value = savePath <- value
+        member _.SavePath = savePath
 
         /// <inheritdoc />
         member _.ServiceKey

--- a/src/Xanthos/Runtime/JvLinkService.fs
+++ b/src/Xanthos/Runtime/JvLinkService.fs
@@ -346,16 +346,7 @@ type JvLinkService
                     let result =
                         executeCom defaultRetryPolicy "SetSavePathDirect" (fun () -> client.SetSavePathDirect path)
 
-                    match result |> Errors.mapComError with
-                    | Error e -> Error e
-                    | Ok() ->
-                        // Also update the cached property for consistency
-                        try
-                            client.SavePath <- path
-                        with _ ->
-                            ()
-
-                        Ok()
+                    result |> Errors.mapComError
                 | None -> Ok()
 
             match savePathResult with
@@ -1448,10 +1439,6 @@ type JvLinkService
         guardedWithInitialisation "SetSavePath" (fun () ->
             match runCom "JVSetSavePath" (fun () -> client.SetSavePathDirect trimmed) with
             | Ok() ->
-                try
-                    client.SavePath <- trimmed
-                with _ ->
-                    ()
                 // Update currentConfig so next initialization uses the new value
                 currentConfig <-
                     { currentConfig with

--- a/tests/Xanthos.UnitTests/ComContractTests.fs
+++ b/tests/Xanthos.UnitTests/ComContractTests.fs
@@ -451,10 +451,10 @@ let ``SaveFlag property should be readable and writable`` () =
     Assert.False(client.SaveFlag)
 
 [<Fact>]
-let ``SavePath property should be readable and writable`` () =
+let ``SavePath property should be readable via SetSavePathDirect`` () =
     let stub = new JvLinkStub()
     let client = stub :> IJvLinkClient
-    client.SavePath <- "C:\\test\\path"
+    client.SetSavePathDirect "C:\\test\\path" |> ignore
     Assert.Equal("C:\\test\\path", client.SavePath)
 
 [<Fact>]

--- a/tests/Xanthos.UnitTests/JvLinkServiceErrorTests.fs
+++ b/tests/Xanthos.UnitTests/JvLinkServiceErrorTests.fs
@@ -64,9 +64,7 @@ let private createStubThatFailsInit () =
             with get () = false
             and set (_) = ()
 
-        member _.SavePath
-            with get () = ""
-            and set (_) = ()
+        member _.SavePath = ""
 
         member _.ServiceKey
             with get () = ""
@@ -134,9 +132,7 @@ let private createStubThatFailsOpen () =
             with get () = false
             and set (_) = ()
 
-        member _.SavePath
-            with get () = ""
-            and set (_) = ()
+        member _.SavePath = ""
 
         member _.ServiceKey
             with get () = ""

--- a/tests/Xanthos.UnitTests/Tests.fs
+++ b/tests/Xanthos.UnitTests/Tests.fs
@@ -566,7 +566,7 @@ let ``All IJvLinkClient properties read and write correctly`` () =
     stubClient.SaveFlag <- false
     Assert.False(stubClient.SaveFlag)
 
-    stubClient.SavePath <- "C:\\temp\\jvdata"
+    stubClient.SetSavePathDirect "C:\\temp\\jvdata" |> ignore
     Assert.Equal("C:\\temp\\jvdata", stubClient.SavePath)
 
     stubClient.ServiceKey <- "TESTKEY123456789"


### PR DESCRIPTION
## Summary

Per JV-Link specification, the `m_savepath` property is read-only and can only be modified via `JVSetSavePath` or `JVSetUIProperties` methods. This PR makes the `SavePath` property read-only across the codebase:

- **IJvLinkClient.fs**: Changed `SavePath` from `string with get, set` to read-only `string`
- **ComJvLinkClient.fs**: Removed setter implementation that was throwing exceptions
- **JvLinkService.fs**: Removed direct `client.SavePath <- value` assignments in `initialize()` and `SetSavePath()`
- **JvLinkStub.fs**: Updated stub implementation to match the read-only interface

The `SetSavePathDirect` method (which calls `JVSetSavePath` COM API) is the proper way to modify the save path and is already being used correctly.

Fixes #1

## Test plan

- [ ] Verify that `JvLinkService.SetSavePath()` still works correctly (uses `SetSavePathDirect` internally)
- [ ] Verify that `JvLinkService.GetSavePath()` returns the configured path
- [ ] Confirm no compilation errors in the F# project
- [ ] Verify stub tests pass with the updated interface