### PR TITLE
fix(interop): reduce checkUseJvGets diagnostic logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
 
+### Fixed
+
+- Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
+
 ## [0.1.0] - 2025-12-10
 
 ### Added

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -281,32 +281,38 @@ type ComJvLinkClient(?useJvGets: bool) =
         | _ -> None
 
     // Determines whether to use JVGets (byte array) instead of JVRead (BSTR).
-    // Priority: 1) constructor parameter, 2) XANTHOS_USE_JVGETS environment variable
-    let checkUseJvGets () =
-        match useJvGetsOverride with
-        | Some value ->
-            Diagnostics.emit $"UseJvGets override={value} (from config)"
-            value
-        | None ->
-            let envValue = Environment.GetEnvironmentVariable("XANTHOS_USE_JVGETS")
-            // Normalize: trim whitespace and convert to lowercase for case-insensitive comparison
-            let normalized =
-                if isNull envValue then
-                    ""
-                else
-                    envValue.Trim().ToLowerInvariant()
+    // Priority: 1) constructor parameter, 2) XANTHOS_USE_JVGETS environment variable.
+    //
+    // The decision is cached because it does not change within a session and emitting this
+    // diagnostic on every record creates excessive log noise.
+    let useJvGetsCached =
+        lazy
+            (match useJvGetsOverride with
+             | Some value ->
+                 Diagnostics.emit $"UseJvGets override={value} (from config)"
+                 value
+             | None ->
+                 let envValue = Environment.GetEnvironmentVariable("XANTHOS_USE_JVGETS")
+                 // Normalize: trim whitespace and convert to lowercase for case-insensitive comparison
+                 let normalized =
+                     if isNull envValue then
+                         ""
+                     else
+                         envValue.Trim().ToLowerInvariant()
 
-            let result =
-                match normalized with
-                | ""
-                | "0"
-                | "false"
-                | "no"
-                | "off" -> false
-                | _ -> true
+                 let result =
+                     match normalized with
+                     | ""
+                     | "0"
+                     | "false"
+                     | "no"
+                     | "off" -> false
+                     | _ -> true
 
-            Diagnostics.emit $"XANTHOS_USE_JVGETS env='{envValue}' -> useJvGets={result}"
-            result
+                 Diagnostics.emit $"XANTHOS_USE_JVGETS env='{envValue}' -> useJvGets={result}"
+                 result)
+
+    let checkUseJvGets () = useJvGetsCached.Value
 
     // JVRead implementation: uses BSTR with UTF-16 byte extraction
     // JVRead returns data as BSTR. JV-Link writes Shift-JIS bytes to the BSTR buffer, but COM
@@ -416,7 +422,6 @@ type ComJvLinkClient(?useJvGets: bool) =
     // Main read dispatcher - selects implementation based on environment variable
     let readRecord () : Result<JvReadOutcome, ComError> =
         if checkUseJvGets () then
-            Diagnostics.emit "Using JVGets path (XANTHOS_USE_JVGETS=1)"
             readRecordViaJvGets ()
         else
             readRecordViaJvRead ()


### PR DESCRIPTION
Fixes #2

### Summary
- Cache the `checkUseJvGets()` decision so the diagnostic message is emitted only once per process/session.
- Remove per-record “Using JVGets path …” diagnostic to avoid log spam during large downloads.
- Update `CHANGELOG.md` under `[Unreleased]`.

### Test
- `nix develop -c dotnet test Xanthos.sln -c Release`