### PR TITLE
fix(interop): reduce checkUseJvGets diagnostic logging (superseded by #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
 
+### Fixed
+
+- Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
+
 ## [0.1.0] - 2025-12-10
 
 ### Added


### PR DESCRIPTION
Superseded by #7 (merged into `develop`). Closing this PR to avoid duplication.

### Summary
- Cache the `checkUseJvGets()` decision so the diagnostic message is emitted only once per process/session.
- Remove per-record “Using JVGets path …” diagnostic to avoid log spam during large downloads.
- Update `CHANGELOG.md` under `[Unreleased]`.

### Test
- `nix develop -c dotnet test Xanthos.sln -c Release`