### PR TITLE
fix(interop): make ServiceKey property read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
+- Make `IJvLinkClient.ServiceKey` property read-only ([#5](https://github.com/cariandrum22/Xanthos/issues/5))
+  - Per JV-Link specification: `ServiceKey` can only be set via `SetServiceKeyDirect` method
 
 ### Fixed
 

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -871,9 +871,7 @@ type ComJvLinkClient(?useJvGets: bool) =
 
         member _.SavePath = getPropertyString "m_savepath"
 
-        member _.ServiceKey
-            with get () = getPropertyString "m_servicekey"
-            and set value = setPropertyString "m_servicekey" value |> ignore
+        member _.ServiceKey = getPropertyString "m_servicekey"
 
         member _.TryGetSaveFlag() =
             tryGetPropertyInt "m_saveflag" |> Result.map (fun v -> v <> 0)

--- a/src/Xanthos/Interop/IJvLinkClient.fs
+++ b/src/Xanthos/Interop/IJvLinkClient.fs
@@ -137,9 +137,13 @@ type IJvLinkClient =
     /// The getter returns an empty string if COM property access fails. Use <see cref="TryGetSavePath"/> for explicit error handling.
     /// </remarks>
     abstract member SavePath: string
-    /// <summary>Gets or sets the service key configured within JV-Link.</summary>
-    /// <remarks>The getter returns an empty string if COM property access fails. Use <see cref="TryGetServiceKey"/> for explicit error handling.</remarks>
-    abstract member ServiceKey: string with get, set
+    /// <summary>Gets the service key configured within JV-Link.</summary>
+    /// <remarks>
+    /// This property is read-only. Per JV-Link specification, m_servicekey can only be modified
+    /// via JVSetServiceKey or JVSetUIProperties methods.
+    /// The getter returns an empty string if COM property access fails. Use <see cref="TryGetServiceKey"/> for explicit error handling.
+    /// </remarks>
+    abstract member ServiceKey: string
     /// <summary>Attempts to retrieve whether downloads are persisted to disk (<c>m_saveflag</c>).</summary>
     /// <returns>Ok(bool) on success, or Error if COM property access fails.</returns>
     abstract member TryGetSaveFlag: unit -> Result<bool, ComError>

--- a/src/Xanthos/Interop/JvLinkStub.fs
+++ b/src/Xanthos/Interop/JvLinkStub.fs
@@ -236,6 +236,7 @@ type JvLinkStub(responses: seq<Result<JvReadOutcome, ComError>>, ?totalSize: int
 
         /// <inheritdoc />
         member _.SetServiceKeyDirect key =
+            serviceKey <- key
             lastServiceKey <- Some key
             Ok()
 
@@ -304,9 +305,7 @@ type JvLinkStub(responses: seq<Result<JvReadOutcome, ComError>>, ?totalSize: int
         member _.SavePath = savePath
 
         /// <inheritdoc />
-        member _.ServiceKey
-            with get () = serviceKey
-            and set value = serviceKey <- value
+        member _.ServiceKey = serviceKey
 
         /// <inheritdoc />
         member _.TryGetSaveFlag() = Ok saveFlag

--- a/src/Xanthos/Runtime/JvLinkService.fs
+++ b/src/Xanthos/Runtime/JvLinkService.fs
@@ -358,16 +358,7 @@ type JvLinkService
                     let result =
                         executeCom defaultRetryPolicy "SetServiceKeyDirect" (fun () -> client.SetServiceKeyDirect key)
 
-                    match result |> Errors.mapComError with
-                    | Error e -> Error e
-                    | Ok() ->
-                        // Also update the cached property for consistency
-                        try
-                            client.ServiceKey <- key
-                        with _ ->
-                            ()
-
-                        Ok()
+                    result |> Errors.mapComError
                 | None -> Ok()
 
     let openSessionFor request =
@@ -1464,10 +1455,6 @@ type JvLinkService
         guardedWithInitialisation "SetServiceKey" (fun () ->
             match runCom "JVSetServiceKey" (fun () -> client.SetServiceKeyDirect trimmed) with
             | Ok() ->
-                try
-                    client.ServiceKey <- trimmed
-                with _ ->
-                    ()
                 // Update currentConfig so next initialization uses the new value
                 currentConfig <-
                     { currentConfig with

--- a/tests/Xanthos.UnitTests/ComContractTests.fs
+++ b/tests/Xanthos.UnitTests/ComContractTests.fs
@@ -458,10 +458,10 @@ let ``SavePath property should be readable via SetSavePathDirect`` () =
     Assert.Equal("C:\\test\\path", client.SavePath)
 
 [<Fact>]
-let ``ServiceKey property should be readable and writable`` () =
+let ``ServiceKey property should be readable via SetServiceKeyDirect`` () =
     let stub = new JvLinkStub()
     let client = stub :> IJvLinkClient
-    client.ServiceKey <- "test-key-123"
+    client.SetServiceKeyDirect "test-key-123" |> ignore
     Assert.Equal("test-key-123", client.ServiceKey)
 
 [<Fact>]

--- a/tests/Xanthos.UnitTests/JvLinkServiceErrorTests.fs
+++ b/tests/Xanthos.UnitTests/JvLinkServiceErrorTests.fs
@@ -66,9 +66,7 @@ let private createStubThatFailsInit () =
 
         member _.SavePath = ""
 
-        member _.ServiceKey
-            with get () = ""
-            and set (_) = ()
+        member _.ServiceKey = ""
 
         member _.TryGetSaveFlag() = Ok false
         member _.TryGetSavePath() = Ok ""
@@ -134,9 +132,7 @@ let private createStubThatFailsOpen () =
 
         member _.SavePath = ""
 
-        member _.ServiceKey
-            with get () = ""
-            and set (_) = ()
+        member _.ServiceKey = ""
 
         member _.TryGetSaveFlag() = Ok false
         member _.TryGetSavePath() = Ok ""

--- a/tests/Xanthos.UnitTests/Tests.fs
+++ b/tests/Xanthos.UnitTests/Tests.fs
@@ -569,7 +569,7 @@ let ``All IJvLinkClient properties read and write correctly`` () =
     stubClient.SetSavePathDirect "C:\\temp\\jvdata" |> ignore
     Assert.Equal("C:\\temp\\jvdata", stubClient.SavePath)
 
-    stubClient.ServiceKey <- "TESTKEY123456789"
+    stubClient.SetServiceKeyDirect "TESTKEY123456789" |> ignore
     Assert.Equal("TESTKEY123456789", stubClient.ServiceKey)
 
     let version = stubClient.JVLinkVersion


### PR DESCRIPTION
Fixes #5

### Summary
- Make `IJvLinkClient.ServiceKey` read-only per JV-Link spec (`m_servicekey` is set via `JVSetServiceKey`/`JVSetUIProperties`, not by property assignment).
- Remove `m_servicekey` property setter from `ComJvLinkClient`.
- Update `JvLinkStub` so `SetServiceKeyDirect` updates the exposed `ServiceKey` value.
- Remove direct `client.ServiceKey <- ...` assignments in `JvLinkService`.
- Update affected unit/E2E tests and `CHANGELOG.md`.

### Test
- `CI=true nix develop -c dotnet test Xanthos.sln -c Release`