### PR TITLE
test(e2e): ensure silks-file output directory exists

### DIFF
--- a/tests/Xanthos.Cli.E2E/CliTests.fs
+++ b/tests/Xanthos.Cli.E2E/CliTests.fs
@@ -723,6 +723,8 @@ type CliTests(output: ITestOutputHelper, fixture: ServiceKeySetupFixture) =
     [<Trait("Category", "Silks")>]
     member _.``silks-file generates silks bitmap``() =
         let outputPath = Path.Combine(Harness.savePath, "silks-test", "output.bmp")
+        // JV-Link requires the output directory to exist.
+        Directory.CreateDirectory(Path.GetDirectoryName outputPath) |> ignore
 
         let result =
             Harness.runCli mode [ "silks-file"; "--pattern"; silksTestPattern; "--output"; outputPath ]


### PR DESCRIPTION
Fixes a Windows COM-mode E2E failure where `silks-file` could return `-118 InvalidInput` because the output directory did not exist.

- Creates the parent directory for the `--output` path in the `silks-file generates silks bitmap` test.
- Aligns behavior with JV-Link `JVFukuFile` requirement (existing output folder).

Closes #10.