### PR TITLE
feat(interop)!: default to JVGets (opt-out via XANTHOS_USE_JVREAD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
 - Make `IJvLinkClient.ServiceKey` property read-only ([#5](https://github.com/cariandrum22/Xanthos/issues/5))
   - Per JV-Link specification: `ServiceKey` can only be set via `SetServiceKeyDirect` method
+- Change default JVRead/JVGets behavior: use JVGets by default; set `XANTHOS_USE_JVREAD=1` to opt out ([#3](https://github.com/cariandrum22/Xanthos/issues/3))
+  - `XANTHOS_USE_JVGETS` is still supported as a legacy override
 
 ### Fixed
 

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -556,8 +556,8 @@ type IJvLinkClient =
     abstract member DeleteFile : filename:string -> Result<unit, ComError>
     abstract member WatchEvent : (string -> unit) -> Result<unit, ComError>
     abstract member WatchEventClose : unit -> Result<unit, ComError>
-    abstract member SavePath : string with get,set
-    abstract member ServiceKey : string with get,set
+    abstract member SavePath : string
+    abstract member ServiceKey : string
     abstract member TotalReadFileSize : int64
     abstract member CurrentFileTimestamp : System.DateTime option
 ```
@@ -575,7 +575,7 @@ The runtime layer lifts `Result<_, ComError>` into `Result<_, XanthosError>` to 
 
 ```fsharp
 // Option 1: Use ComClientFactory with 'use' binding
-// Parameter: useJvGets (None = use env var XANTHOS_USE_JVGETS)
+// Parameter: useJvGets (None = env vars; XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy)
 match ComClientFactory.tryCreate None with
 | Ok client ->
     use client = client  // IJvLinkClient inherits IDisposable

--- a/samples/Xanthos.Cli/Execution.fs
+++ b/samples/Xanthos.Cli/Execution.fs
@@ -701,7 +701,11 @@ let runCaptureFixtures ctx args =
         let ctxForFixtures =
             if args.UseJvGets then
                 printfn "Using JVGets mode (--use-jvgets)"
-                { ctx with Config = { ctx.Config with UseJvGets = Some true } }
+
+                { ctx with
+                    Config =
+                        { ctx.Config with
+                            UseJvGets = Some true } }
             else
                 ctx
 

--- a/samples/Xanthos.Cli/Execution.fs
+++ b/samples/Xanthos.Cli/Execution.fs
@@ -697,18 +697,15 @@ let runCaptureFixtures ctx args =
         printfn "Run this command on Windows with JV-Link installed."
         2
     | Com ->
-        // Set environment variable for JVGets mode only if explicitly requested via CLI option
-        // This preserves any existing environment variable setting when --use-jvgets is not specified
-        if args.UseJvGets then
-            Environment.SetEnvironmentVariable("XANTHOS_USE_JVGETS", "1")
-            printfn "Using JVGets mode (--use-jvgets)"
-        else
-            // Check if environment variable is already set
-            match Environment.GetEnvironmentVariable("XANTHOS_USE_JVGETS") with
-            | "1" -> printfn "Using JVGets mode (from environment variable)"
-            | _ -> ()
+        // Force JVGets when explicitly requested, regardless of env var defaults.
+        let ctxForFixtures =
+            if args.UseJvGets then
+                printfn "Using JVGets mode (--use-jvgets)"
+                { ctx with Config = { ctx.Config with UseJvGets = Some true } }
+            else
+                ctx
 
-        match tryCreateService ctx with
+        match tryCreateService ctxForFixtures with
         | Error msg ->
             printfn "ERROR: COM client creation failed: %s" msg
             2

--- a/samples/Xanthos.Cli/Program.fs
+++ b/samples/Xanthos.Cli/Program.fs
@@ -16,6 +16,8 @@ Global Options:
   --save-path <path>      Directory for persisted files (or XANTHOS_JVLINK_SAVE_PATH).
   --stub                  Force stub mode (default on non-Windows).
   --diag                  Enable COM diagnostics output.
+  --use-jvgets            Force JVGets (default) regardless of env vars.
+  --no-jvgets             Force JVRead (equivalent to XANTHOS_USE_JVREAD=1).
   --help                  Show this help text.
 
 Commands:
@@ -106,7 +108,7 @@ Commands:
       --from <timestamp>    Start time YYYYMMDDHHmmss (default: 30 days ago).
       --to <timestamp>      End time YYYYMMDDHHmmss (optional).
       --max-records <n>     Max records per type (default: 10).
-      --use-jvgets          Use JVGets instead of JVRead.
+      --use-jvgets          Force JVGets (default).
 """
 
 let private printHelp () =

--- a/samples/Xanthos.Cli/Types.fs
+++ b/samples/Xanthos.Cli/Types.fs
@@ -34,7 +34,7 @@ type GlobalSettings =
         StubPreference: StubPreference
         EnableDiagnostics: bool
         /// When Some true, use JVGets (byte array) instead of JVRead (BSTR).
-        /// When None, falls back to XANTHOS_USE_JVGETS environment variable.
+        /// When None, falls back to environment variables (XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy).
         UseJvGets: bool option
     }
 

--- a/src/Xanthos/Interop/ComClientFactory.fs
+++ b/src/Xanthos/Interop/ComClientFactory.fs
@@ -8,7 +8,7 @@ module ComClientFactory =
     /// Attempts to create a COM-backed JV-Link client.
     /// </summary>
     /// <param name="useJvGets">Optional flag to use JVGets API instead of JVRead.
-    /// When None, falls back to XANTHOS_USE_JVGETS environment variable.</param>
+    /// When None, falls back to environment variables (XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy).</param>
     /// <returns>
     /// Ok with the client on success, or Error with details on failure.
     /// </returns>

--- a/src/Xanthos/Runtime/Configuration.fs
+++ b/src/Xanthos/Runtime/Configuration.fs
@@ -37,7 +37,7 @@ type JvLinkConfig =
         SavePath: string option
         ServiceKey: string option
         /// When Some true, use JVGets (byte array) instead of JVRead (BSTR).
-        /// When None, falls back to XANTHOS_USE_JVGETS environment variable.
+        /// When None, falls back to environment variables (XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy).
         UseJvGets: bool option
     }
 

--- a/src/Xanthos/Xanthos.fsproj
+++ b/src/Xanthos/Xanthos.fsproj
@@ -9,7 +9,7 @@
     <PackageId>Xanthos</PackageId>
     <AssemblyName>Xanthos</AssemblyName>
     <RootNamespace>Xanthos</RootNamespace>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>cariandrum22</Authors>
     <Description>F# wrapper library for the JRA-VAN JV-Link COM API. Provides type-safe access to Japanese horse racing data.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/README.md
+++ b/tests/README.md
@@ -252,7 +252,7 @@ Expected: All tests pass or skip appropriately based on COM availability.
        "Xanthos.Cli": {
          "commandLineArgs": "--sid YOUR_SID fetch --spec RACE --from 20240101",
          "environmentVariables": {
-           "XANTHOS_USE_JVGETS": "0"
+           "XANTHOS_USE_JVREAD": "1"
          }
        }
      }
@@ -273,16 +273,16 @@ Get-ChildItem -Recurse ./fixtures/*.bin | Measure-Object
 
 Expected: `.bin` and `.meta.json` files created for each record type.
 
-### 4. JVGets Mode Verification
+### 4. JVRead Mode Verification
 
-Test the JVGets API path:
+Test the JVRead API path (opt-out):
 
 ```powershell
-$env:XANTHOS_USE_JVGETS = "1"
+$env:XANTHOS_USE_JVREAD = "1"
 dotnet run --project samples/Xanthos.Cli -- --sid YOUR_SID fetch --spec RACE --from 20240101
 ```
 
-Expected: Data fetched using JVGets instead of JVOpen.
+Expected: Data fetched using JVRead instead of JVGets.
 
 ## Verification Checklist
 
@@ -300,7 +300,8 @@ Use this checklist before releases:
 - [ ] CLI E2E (COM mode) - All pass
 - [ ] Visual Studio debug run - Success
 - [ ] Fixture capture - Files generated
-- [ ] JVGets mode - Data fetched
+- [ ] JVGets mode (default) - Data fetched
+- [ ] JVRead mode (XANTHOS_USE_JVREAD=1) - Data fetched
 
 **Record Types Verified:**
 - [ ] TK (Track info)
@@ -384,11 +385,12 @@ $env:XANTHOS_SID = "YOUR_SID"
 # 1. Verify COM instantiation works
 dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID version
 
-# 2. Verify data fetching (JVRead path)
+# 2. Verify data fetching (JVRead path / opt-out)
+$env:XANTHOS_USE_JVREAD = "1"
 dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
 
-# 3. Verify JVGets path (if using Gets mode)
-$env:XANTHOS_USE_JVGETS = "1"
+# 3. Verify JVGets path (default / opt-in)
+$env:XANTHOS_USE_JVREAD = "0"
 dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
 
 # 4. Run E2E test suite in COM mode
@@ -410,7 +412,7 @@ Before each release, fill out and include in the release notes:
 **Smoke Test Results:**
 - [ ] `version` command: COM client instantiated successfully
 - [ ] `fetch` command (JVRead): Data retrieved and parsed
-- [ ] `fetch` command (JVGets): Data retrieved via Gets API (if applicable)
+- [ ] `fetch` command (JVGets): Data retrieved via JVGets (default)
 - [ ] E2E test suite (COM mode): All tests pass
 
 **Verified By:** ____________


### PR DESCRIPTION
Changes the default JV-Link read mode selection:

- Default to **JVGets**.
- Set `XANTHOS_USE_JVREAD=1` to opt out to **JVRead**.
- Keep `XANTHOS_USE_JVGETS` as a legacy override for compatibility.

Also:
- Updates docs/samples/tests to match the new behavior.
- Bumps the package version to `0.2.0` (release will be handled separately).

Related: #3.

Note: Branch naming convention documentation was split out to #13.