### PR TITLE
fix: align docs/CLI with spec and COM behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
+- Avoid unsupported COM property access for `ParentHWnd` (write-only) and `m_payflag` (read-only); return clear `Unsupported` errors from `JvLinkService` in COM mode ([#14](https://github.com/cariandrum22/Xanthos/issues/14))
 
 ## [0.1.0] - 2025-12-10
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ All commands support global options: `--sid --service-key --save-path [--stub] [
 | `set-save-flag` / `get-save-flag` | Toggle/query persistence flag |
 | `set-save-path` / `get-save-path` | Configure/query save path |
 | `set-service-key` / `get-service-key` | Configure/query service key |
-| `set-payoff-dialog` / `get-payoff-dialog` | Suppress payoff dialogs |
-| `set-parent-hwnd` / `get-parent-hwnd` | Configure/query parent window handle (UI) |
+| `set-payoff-dialog` / `get-payoff-dialog` | Query payoff dialog suppression (`set-payoff-dialog` is not supported in COM; use `set-ui-properties`) |
+| `set-parent-hwnd` / `get-parent-hwnd` | Configure/query parent window handle (`get-parent-hwnd` is not supported in COM; `ParentHWnd` is write-only) |
 | `course-file` / `course-file2` | Retrieve course diagram (path + explanation / path only) |
 | `silks-file` | Generate silks bitmap file |
 | `silks-binary` | Retrieve silks bytes |

--- a/design/architecture/api-coverage.md
+++ b/design/architecture/api-coverage.md
@@ -13,7 +13,7 @@ Status legend: ✅ Implemented / ⚠️ Partial (workaround or property-based) /
 | JVSetSavePath | ✅ | Cache path | `JvLinkService.SetSavePath` (calls `JVSetSavePath`) |
 | JVOpen | ✅ | Batch download | Implemented; returns file count |
 | JVRTOpen | ✅ | Real-time odds | `StreamRealtimePayloads`, `StreamRealtimeAsync` (alias `StreamRealtimePayloadsAsync`) |
-| JVStatus | ✅ | Progress check | Implemented via `IJvLinkClient.Status`; returns download % |
+| JVStatus | ✅ | Progress check | Implemented via `IJvLinkClient.Status`; returns completed file count |
 | JVRead | ✅ | Data retrieval | Implemented with Shift-JIS handling |
 | JVGets | ✅ | Line read | SAFEARRAY byte extraction + Shift-JIS decode; avoids JV-Link internal Unicode conversion |
 | JVSkip | ✅ | Skip file | Implemented via `IJvLinkClient.Skip` |
@@ -83,8 +83,8 @@ This section provides expected return values, error codes, and specification ref
 | m_TotalReadFilesize | ✅ | `JvLinkService.GetTotalReadFileSize` |
 | m_CurrentReadFilesize | ✅ | `JvLinkService.GetCurrentReadFileSize` |
 | m_CurrentFileTimestamp | ✅ | `JvLinkService.GetCurrentFileTimestamp` |
-| ParentHWnd | ✅ | `JvLinkService.SetParentWindowHandle` / `GetParentWindowHandle` (write-only in COM; read fails) |
-| m_payflag | ✅ | `JvLinkService.SetPayoffDialogSuppressed` / `GetPayoffDialogSuppressed` (read-only in COM; write fails) |
+| ParentHWnd | ✅ | `JvLinkService.SetParentWindowHandle` / `GetParentWindowHandle` (write-only in COM; read not supported) |
+| m_payflag | ✅ | `JvLinkService.SetPayoffDialogSuppressed` / `GetPayoffDialogSuppressed` (read-only in COM; write not supported) |
 
 ## Update Guidelines
 

--- a/design/tests/e2e-cli.md
+++ b/design/tests/e2e-cli.md
@@ -16,8 +16,8 @@ This document defines the end-to-end scenarios that the command-line tool must e
 
 | Command | JV-Link APIs | Purpose / Expected Outcome | Stub Coverage |
 | --- | --- | --- | --- |
-| `download --spec <dataspec> --from <ts> [--option <1-4>] [--output <dir>]` | `JVOpen`, repeated `JVRead`, `JVClose` | Materialises all payloads for a dataspec, logs download counts, handles `FileBoundary`/`DownloadPending`. | Yes |
-| `realtime --spec <dataspec> [--from <ts>]` | `JVRTOpen`, repeated `JVRead`, `JVCancel` | Streams realtime payloads until cancelled. | Yes |
+| `download --spec <dataspec> --from <ts> [--option <1-4>] [--output <dir>]` | `JVOpen`, repeated `JVRead`/`JVGets`, `JVClose` | Materialises all payloads for a dataspec, logs download counts, handles `FileBoundary`/`DownloadPending`. | Yes |
+| `realtime --spec <dataspec> --key <key> [--continuous]` | `JVRTOpen`, repeated `JVRead`/`JVGets`, `JVCancel` | Streams realtime payloads (continuous mode polls until cancelled). | Yes |
 | `status` | `JVStatus` | Reports current download status. | Yes |
 | `skip` | `JVSkip` | Skips current file in session. | Yes |
 | `cancel` | `JVCancel` | Cancels current session. | Yes |
@@ -32,13 +32,18 @@ This document defines the end-to-end scenarios that the command-line tool must e
 | `movie-play --key <search>` | `JVMVPlay` | Requests movie playback. | Stub: simulated |
 | `movie-play-with-type --movie-type <code> --key <search>` | `JVMVPlayWithType` | Requests movie playback by type. | Stub: simulated |
 | `movie-open --movie-type <code> --search-key <key>` | `JVMVOpen`, `JVMVRead` | Retrieves all workout video listings in one call via `FetchWorkoutVideos`. | Yes |
-| `version` | `JVLink.Version` | Displays JV-Link version information. | Yes |
+| `version` | `m_JVLinkVersion` | Displays JV-Link version information. | Yes |
 | `set-save-flag --value <bool>` | `JVSetSaveFlag` | Sets save flag. | Yes |
-| `get-save-flag` | `JVGetSaveFlag` | Gets current save flag. | Yes |
+| `get-save-flag` | `m_saveflag` | Gets current save flag. | Yes |
 | `set-save-path --value <path>` | `JVSetSavePath` | Sets save path directory. | Yes |
-| `get-save-path` | `JVGetSavePath` | Gets current save path. | Yes |
+| `get-save-path` | `m_savepath` | Gets current save path. | Yes |
 | `set-service-key --value <key>` | `JVSetServiceKey` | Sets service key. | Yes |
-| `get-service-key` | `JVGetServiceKey` | Gets current service key. | Yes |
+| `get-service-key` | `m_servicekey` | Gets current service key. | Yes |
+| `set-parent-hwnd --value <handle>` | `ParentHWnd` (set) | Sets dialog owner window handle. | Yes |
+| `get-parent-hwnd` | `ParentHWnd` (get) | Gets dialog owner window handle (not supported in COM; `ParentHWnd` is write-only). | Yes (stub only) |
+| `set-payoff-dialog --value <bool>` | `m_payflag` (set) | Suppresses payoff dialogs (not supported in COM; `m_payflag` is read-only). | Yes (stub only) |
+| `get-payoff-dialog` | `m_payflag` (get) | Gets payoff dialog suppression setting. | Yes |
+| `set-ui-properties` | `JVSetUIProperties` | Shows JV-Link configuration dialog and updates registry. | Stub: simulated |
 | `capture-fixtures --output <dir> --specs <list> --from <ts> [--to <ts>] [--max-records <n>] [--use-jvgets]` | `JVOpen`, `JVRead`/`JVGets` | Captures real COM records as test fixtures (Windows only). | No (requires COM) |
 
 ## Execution Flow

--- a/samples/Xanthos.Cli/Execution.fs
+++ b/samples/Xanthos.Cli/Execution.fs
@@ -527,7 +527,7 @@ let runTotalReadSize ctx =
     withService ctx (fun service ->
         let _ = printEvidence ctx service
 
-        match service.GetTotalReadFileSize() with
+        match service.GetTotalReadFileSizeBytes() with
         | Ok size ->
             printfn "Total read file size: %d bytes" size
             0

--- a/samples/Xanthos.Cli/Program.fs
+++ b/samples/Xanthos.Cli/Program.fs
@@ -23,7 +23,7 @@ Global Options:
 Commands:
 
   Data Retrieval:
-    download              Bulk download payloads via JVOpen + JVRead.
+    download              Bulk download payloads via JVOpen + JVRead/JVGets.
       --spec <dataspec>     Data specification (required, e.g., RACE, TOKU).
       --from <timestamp>    Start time YYYYMMDDHHmmss (required).
       --option <1-4>        JVOpen option (default: 1).
@@ -61,8 +61,8 @@ Commands:
     get-service-key       Get current service key.
     set-parent-hwnd       Set parent window handle.
       --value <handle>      Handle value as integer (required).
-    get-parent-hwnd       Get current parent window handle.
-    set-payoff-dialog     Control payoff dialog display.
+    get-parent-hwnd       Get current parent window handle (not supported in COM).
+    set-payoff-dialog     Control payoff dialog display (not supported in COM; use set-ui-properties).
       --value <bool>        Enable/disable (required).
     get-payoff-dialog     Get payoff dialog setting.
     set-ui-properties     Synchronize UI state.

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -927,6 +927,7 @@ type ComJvLinkClient(?useJvGets: bool) =
         member _.TryGetParentWindowHandle() =
             // NOTE: ParentHWnd is write-only in COM mode; reading fails.
             Error(InvalidState "ParentHWnd cannot be read in COM mode (property is write-only).")
+
         member _.TryGetPayoffDialogSuppressed() = tryGetPropertyBool "m_payflag"
 
         member _.JVLinkVersion = getPropertyString "m_JVLinkVersion"

--- a/src/Xanthos/Interop/IJvLinkClient.fs
+++ b/src/Xanthos/Interop/IJvLinkClient.fs
@@ -101,9 +101,16 @@ type IJvLinkClient =
     abstract member SetServiceKeyDirect: key: string -> Result<unit, ComError>
     /// <summary>Sets the save path via `JVSetSavePath`.</summary>
     abstract member SetSavePathDirect: path: string -> Result<unit, ComError>
-    /// <summary>Sets the parent window handle via property assignment.</summary>
+    /// <summary>Sets the parent window handle for JV-Link dialogs (<c>ParentHWnd</c>).</summary>
+    /// <remarks>
+    /// In COM mode, <c>ParentHWnd</c> is write-only: reading it back is not supported.
+    /// </remarks>
     abstract member SetParentWindowHandleDirect: handle: IntPtr -> Result<unit, ComError>
-    /// <summary>Sets whether payoff dialogs are suppressed via property assignment.</summary>
+    /// <summary>Attempts to set whether payoff dialogs are suppressed (<c>m_payflag</c>).</summary>
+    /// <remarks>
+    /// In COM mode, <c>m_payflag</c> is effectively read-only (write fails). Users can still change this
+    /// setting interactively via <see cref="SetUiProperties"/> (JVSetUIProperties dialog).
+    /// </remarks>
     abstract member SetPayoffDialogSuppressedDirect: suppressed: bool -> Result<unit, ComError>
     /// <summary>Retrieves a course diagram with explanation.</summary>
     abstract member CourseFile: key: string -> Result<string * string, ComError>
@@ -167,7 +174,8 @@ type IJvLinkClient =
     /// <returns>Ok(DateTime option) on success, or Error if COM property access fails.</returns>
     abstract member TryGetCurrentFileTimestamp: unit -> Result<DateTime option, ComError>
     /// <summary>Attempts to retrieve the parent window handle for JV dialogs.</summary>
-    /// <returns>Ok(IntPtr) on success, or Error if COM property access fails.</returns>
+    /// <remarks>In COM mode, <c>ParentHWnd</c> is write-only and cannot be read.</remarks>
+    /// <returns>Ok(IntPtr) on success, or Error if the value cannot be read.</returns>
     abstract member TryGetParentWindowHandle: unit -> Result<IntPtr, ComError>
     /// <summary>Attempts to retrieve whether payoff dialogs are suppressed (<c>m_payflag</c>).</summary>
     /// <returns>Ok(bool) on success, or Error if COM property access fails.</returns>
@@ -185,8 +193,15 @@ type IJvLinkClient =
     /// <remarks>The getter returns None if COM property access fails. Use <see cref="TryGetCurrentFileTimestamp"/> for explicit error handling.</remarks>
     abstract member CurrentFileTimestamp: DateTime option
     /// <summary>Gets or sets the parent window handle for JV dialogs.</summary>
-    /// <remarks>The getter returns IntPtr.Zero if COM property access fails. Use <see cref="TryGetParentWindowHandle"/> for explicit error handling.</remarks>
+    /// <remarks>
+    /// In COM mode, <c>ParentHWnd</c> is write-only. The getter returns IntPtr.Zero.
+    /// Use <see cref="TryGetParentWindowHandle"/> for explicit error handling.
+    /// </remarks>
     abstract member ParentWindowHandle: IntPtr with get, set
     /// <summary>Gets or sets whether payoff dialogs are suppressed (<c>m_payflag</c>).</summary>
-    /// <remarks>The getter returns false if COM property access fails. Use <see cref="TryGetPayoffDialogSuppressed"/> for explicit error handling.</remarks>
+    /// <remarks>
+    /// In COM mode, <c>m_payflag</c> is effectively read-only: setting it programmatically is not supported.
+    /// The setter is best-effort and may be ignored. Use <see cref="SetUiProperties"/> to change the value interactively.
+    /// The getter returns false if COM property access fails. Use <see cref="TryGetPayoffDialogSuppressed"/> for explicit error handling.
+    /// </remarks>
     abstract member PayoffDialogSuppressed: bool with get, set

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF,0B12" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 10
 ```
 
@@ -32,7 +32,7 @@ dotnet run --project samples/Xanthos.Cli -- \
 |--------|-------------|
 | `--output` | Directory to save fixtures (required) |
 | `--specs` | Comma-separated list of data specs (required) |
-| `--from` | Start date for data retrieval (required) |
+| `--from` | Start time for data retrieval (`yyyyMMdd` or `yyyyMMddHHmmss`; required) |
 | `--max-records` | Max records per record type (default: 10) |
 
 ### Fixture Directory Structure
@@ -108,7 +108,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     --sid YOUR_SID capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 10
 ```
 
@@ -118,7 +118,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     --sid YOUR_SID capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF,0B12,0B31,BLOD" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 5
 ```
 
@@ -128,7 +128,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     --sid YOUR_SID capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF,0B12,0B31,BLOD,SNAP,YSCH" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 3
 ```
 
@@ -233,7 +233,8 @@ Run the E2E test suite in COM mode on Windows:
 ```powershell
 # Set environment for COM mode
 $env:XANTHOS_E2E_MODE = "COM"
-$env:XANTHOS_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SERVICE_KEY = "YOUR_SERVICE_KEY"
 
 # Run E2E tests
 dotnet test tests/Xanthos.Cli.E2E --filter "Category=E2E"
@@ -248,9 +249,9 @@ Expected: All tests pass or skip appropriately based on COM availability.
 3. Configure launch settings with your SID:
    ```json
    {
-     "profiles": {
-       "Xanthos.Cli": {
-         "commandLineArgs": "--sid YOUR_SID fetch --spec RACE --from 20240101",
+       "profiles": {
+         "Xanthos.Cli": {
+         "commandLineArgs": "--sid YOUR_SID download --spec RACE --from 20240101",
          "environmentVariables": {
            "XANTHOS_USE_JVREAD": "1"
          }
@@ -279,7 +280,7 @@ Test the JVRead API path (opt-out):
 
 ```powershell
 $env:XANTHOS_USE_JVREAD = "1"
-dotnet run --project samples/Xanthos.Cli -- --sid YOUR_SID fetch --spec RACE --from 20240101
+dotnet run --project samples/Xanthos.Cli -- --sid YOUR_SID download --spec RACE --from 20240101
 ```
 
 Expected: Data fetched using JVRead instead of JVGets.
@@ -380,18 +381,19 @@ Before tagging a release, the following COM smoke tests **MUST** pass on a Windo
 ```powershell
 # Set environment for COM mode
 $env:XANTHOS_E2E_MODE = "COM"
-$env:XANTHOS_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SERVICE_KEY = "YOUR_SERVICE_KEY"
 
 # 1. Verify COM instantiation works
-dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID version
+dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_E2E_SID version
 
 # 2. Verify data fetching (JVRead path / opt-out)
 $env:XANTHOS_USE_JVREAD = "1"
-dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
+dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_E2E_SID --service-key $env:XANTHOS_E2E_SERVICE_KEY download --spec RACE --from 20240101
 
 # 3. Verify JVGets path (default / opt-in)
 $env:XANTHOS_USE_JVREAD = "0"
-dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
+dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_E2E_SID --service-key $env:XANTHOS_E2E_SERVICE_KEY download --spec RACE --from 20240101
 
 # 4. Run E2E test suite in COM mode
 dotnet test tests/Xanthos.Cli.E2E --filter "Category=E2E"
@@ -411,8 +413,8 @@ Before each release, fill out and include in the release notes:
 
 **Smoke Test Results:**
 - [ ] `version` command: COM client instantiated successfully
-- [ ] `fetch` command (JVRead): Data retrieved and parsed
-- [ ] `fetch` command (JVGets): Data retrieved via JVGets (default)
+- [ ] `download` command (JVRead): Data retrieved and parsed
+- [ ] `download` command (JVGets): Data retrieved via JVGets (default)
 - [ ] E2E test suite (COM mode): All tests pass
 
 **Verified By:** ____________

--- a/tests/Xanthos.Cli.E2E/README.md
+++ b/tests/Xanthos.Cli.E2E/README.md
@@ -12,7 +12,7 @@ End-to-end test project that runs `samples/Xanthos.Cli` via `dotnet run` and ver
 |----------|-------|----------|
 | Basic | 5 | `version`, `download`, `set-save-flag`, `help` |
 | Realtime | 1 | `realtime` |
-| Config Round-trip | 5 | `get/set-save-flag`, `get/set-save-path`, `get/set-service-key`, `get/set-payoff-dialog`, `get/set-parent-hwnd` |
+| Config | 5 | `get/set-save-flag`, `get/set-save-path`, `get-service-key`, `get-payoff-dialog`, `set-parent-hwnd` |
 | Course Diagram | 2 | `course-file`, `course-file2` |
 | Silks | 2 | `silks-file`, `silks-binary` |
 | Movie | 5 | `movie-check`, `movie-check-with-type`, `movie-play`, `movie-play-with-type`, `movie-open` |
@@ -32,6 +32,10 @@ End-to-end test project that runs `samples/Xanthos.Cli` via `dotnet run` and ver
 |------|-------------|------------|
 | Stub (default) | Runs CLI with `--stub` to verify command structure without COM | `dotnet test tests/Xanthos.Cli.E2E` |
 | COM | Runs on Windows with real JV-Link installation | Set `XANTHOS_E2E_MODE=COM` and required env vars |
+
+> **Note:** Some configuration commands are not fully round-trippable in COM mode due to JV-Link limitations:
+> - `ParentHWnd` is write-only (so `get-parent-hwnd` is not supported)
+> - `m_payflag` is read-only (so `set-payoff-dialog` is not supported)
 
 ## Environment Variables
 

--- a/tests/Xanthos.UnitTests/FixtureParserTests.fs
+++ b/tests/Xanthos.UnitTests/FixtureParserTests.fs
@@ -161,7 +161,7 @@ module KnownRecordTypes =
 ///     --sid YOUR_SID capture-fixtures \
 ///     --output tests/fixtures \
 ///     --specs "RACE,DIFF" \
-///     --from "2024-01-01" \
+///     --from "20240101" \
 ///     --max-records 5
 /// </summary>
 type FixtureParserTests() =


### PR DESCRIPTION
Closes #14.

## Summary

- Avoid unsupported JV-Link COM property access (ParentHWnd read / m_payflag write) and return clear `Unsupported` errors from `JvLinkService`.
- Fix CLI `total-read-size` to report bytes correctly.
- Align docs/design/test docs with the current CLI/API behavior (JVStatus meaning, realtime args, manual verification commands/formats).

## Notes

- Intended to be merged into `develop` and included in the `v0.2.0` release.
- No tags pushed / no release workflow triggered.
