### PR TITLE
docs: document merge strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Xanthos
 
-Thank you for your interest in contributing to Xanthos! This document explains how to contribute to the project.
+Thank you for your interest in contributing to Xanthos!
+This document explains how to contribute to the project.
 
 ## Development Environment Setup
 
@@ -38,7 +39,7 @@ dotnet test
 
 This project follows a GitFlow-like branching strategy.
 
-```
+```text
 main (release branch)
   ↑ On merge: version increment + CHANGELOG finalization
 develop (development branch)
@@ -47,13 +48,14 @@ feature/*, fix/* (topic branches)
 ```
 
 | Branch | Purpose | Merge Target |
-|--------|---------|--------------|
+| ------ | ------- | ------------ |
 | `main` | Stable releases. Published to NuGet | - |
 | `develop` | Development integration. Next release candidate | `main` |
 | `feature/*` | New feature development | `develop` |
 | `fix/*` | Bug fixes | `develop` |
 
 **Important**:
+
 - Topic branches are created from `develop` and merged back to `develop`
 - Merging to `main` is only done during releases
 - Direct commits to `main` are prohibited
@@ -63,11 +65,13 @@ feature/*, fix/* (topic branches)
 Use a consistent, descriptive branch name format:
 
 - **With an Issue**: `<type>/<issue-number>-<slug>`
-- **Without an Issue**: `<type>/<slug>` (or `<type>/no-issue-<slug>` if you want to make that explicit)
+- **Without an Issue**: `<type>/<slug>`
+  (or `<type>/no-issue-<slug>` if you want to make that explicit)
 
 Rules:
 
-- `type` should align with Conventional Commits types (e.g. `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `ci/`, `chore/`)
+- `type` should align with Conventional Commits types (e.g. `feat/`, `fix/`, `docs/`,
+  `refactor/`, `test/`, `ci/`, `chore/`)
 - `issue-number` is digits only (no `issue-` prefix)
 - `slug` should be short, kebab-case, and descriptive
 
@@ -87,9 +91,10 @@ Examples:
 
 ### Commit Messages
 
-This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+specification.
 
-```
+```text
 <type>[optional scope]: <description>
 
 [optional body]
@@ -100,7 +105,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 **Types:**
 
 | Type | Description | SemVer |
-|------|-------------|--------|
+| ---- | ----------- | ----- |
 | `feat` | New feature | MINOR |
 | `fix` | Bug fix | PATCH |
 | `docs` | Documentation only | - |
@@ -116,7 +121,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 
 Append `!` after type/scope or add `BREAKING CHANGE:` in footer:
 
-```
+```text
 feat!: remove deprecated API
 
 BREAKING CHANGE: The old API has been removed.
@@ -124,7 +129,7 @@ BREAKING CHANGE: The old API has been removed.
 
 **Examples:**
 
-```
+```text
 feat: add realtime data streaming support
 fix: correct SavePath property access
 docs: update installation instructions
@@ -168,7 +173,7 @@ dotnet fsharplint lint src tests
 ### Test Categories
 
 | Category | Description | Environment |
-|----------|-------------|-------------|
+| -------- | ----------- | ----------- |
 | Unit | Pure F# unit tests | CI (any OS) |
 | Property | FsCheck property-based tests | CI (any OS) |
 | Fixtures | Fixture-based parser tests | CI (if fixtures exist) |
@@ -201,7 +206,8 @@ XANTHOS_E2E_MODE=COM XANTHOS_SID=YOUR_SID dotnet test tests/Xanthos.Cli.E2E
 ### Manual COM Verification
 
 Some functionality requires testing with real JV-Link COM on Windows.
-See [tests/README.md - Manual COM Verification](tests/README.md#manual-com-verification) for:
+See [tests/README.md - Manual COM Verification](tests/README.md#manual-com-verification)
+for:
 
 - Step-by-step verification procedures
 - Pre-release checklist template
@@ -255,8 +261,10 @@ Brief description of changes
 To keep the `develop` history readable and consistent:
 
 - **Topic branches → `develop`**: prefer **Squash and merge** (one PR = one commit).
-- **`develop` → `main` (releases)**: prefer a **merge commit** to preserve a clear release boundary.
-- **Rebase and merge**: only use when each commit is intentionally curated and meaningful on its own.
+- **`develop` → `main` (releases)**: prefer a **merge commit** to preserve a clear
+  release boundary.
+- **Rebase and merge**: only use when each commit is intentionally curated and
+  meaningful on its own.
 
 ## Architecture
 
@@ -295,6 +303,7 @@ When merging a PR, add changes to the `[Unreleased]` section in `CHANGELOG.md`:
 ```
 
 Categories:
+
 - **Added**: New features
 - **Changed**: Changes to existing features
 - **Deprecated**: Features that are deprecated
@@ -326,7 +335,8 @@ Versions are centrally managed in `Directory.Build.props`.
 Before tagging a release, complete the following:
 
 1. **CI Tests**: All GitHub Actions workflows pass
-2. **Manual COM Verification**: Complete the [verification checklist](tests/README.md#verification-checklist) on Windows
+2. **Manual COM Verification**: Complete the
+   [verification checklist](tests/README.md#verification-checklist) on Windows
 3. **CHANGELOG**: Finalize `[Unreleased]` section with release version
 4. **Version**: Update version in `Directory.Build.props`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,14 @@ Brief description of changes
 - [ ] CHANGELOG.md updated
 ```
 
+### Merge Strategy
+
+To keep the `develop` history readable and consistent:
+
+- **Topic branches → `develop`**: prefer **Squash and merge** (one PR = one commit).
+- **`develop` → `main` (releases)**: prefer a **merge commit** to preserve a clear release boundary.
+- **Rebase and merge**: only use when each commit is intentionally curated and meaningful on its own.
+
 ## Architecture
 
 The project follows a three-layer architecture:

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
 # Xanthos
 
-[![CI](https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml/badge.svg)](https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml)
-[![NuGet](https://img.shields.io/nuget/v/Xanthos.svg)](https://www.nuget.org/packages/Xanthos)
-[![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI][badge-ci]][link-ci]
+[![NuGet][badge-nuget]][link-nuget]
+[![.NET][badge-dotnet]][link-dotnet]
+[![License: MIT][badge-license]][link-license]
 
 F# wrapper library for the JRA-VAN Data Lab. JV-Link COM API.
 
 ## Overview
 
-Xanthos provides a type-safe, modern F# interface to the legacy JV-Link ActiveX COM component. It leverages F#'s powerful type system to model the JRA-VAN API safely, converting COM exceptions and error codes into idiomatic `Result<'T, Error>` workflows.
+Xanthos provides a type-safe, modern F# interface to the legacy JV-Link ActiveX
+COM component. It leverages F#'s powerful type system to model the JRA-VAN API safely,
+converting COM exceptions and error codes into idiomatic `Result<'T, Error>` workflows.
 
 ### Features
 
 - **Type-safe API**: Discriminated unions and records model JV-Link data structures
 - **Error handling**: COM errors mapped to F# Result types
 - **Streaming support**: AsyncSeq-based streaming for large data sets
-- **Cross-platform development**: Core logic runs on any .NET platform; COM interop requires Windows
-- **Stub mode**: Deterministic `JvLinkStub` enables full testability in CI where COM is unavailable
+- **Cross-platform development**: Core logic runs on any .NET platform
+  (COM interop requires Windows)
+- **Stub mode**: Deterministic `JvLinkStub` enables full testability in CI
+  where COM is unavailable
 - **CLI tooling**: Rich command surface with E2E coverage in stub mode
 
 ## Installation
 
-> **Requirements**: .NET 10 SDK. COM interop functionality is only available on Windows.
+> **Requirements**: .NET 10 SDK. COM interop functionality is only available on
+> Windows.
 >
-> **Important (Windows COM mode):** JV-Link COM server is a 32-bit (x86) component and only works
-> in 32-bit processes. When using `ComJvLinkClient`, your application must target **x86** or use
-> **AnyCPU with "Prefer 32-bit" enabled**. Running in a 64-bit process will result in
-> `REGDB_E_CLASSNOTREG` errors. The `ComClientFactory.tryCreate` function performs an early
-> check and returns a clear error message if called from a 64-bit process.
+> **Important (Windows COM mode):**
+> JV-Link COM server is a 32-bit (x86) component and only works in 32-bit
+> processes.
+> When using `ComJvLinkClient`, your application must target **x86** or use
+> **AnyCPU with "Prefer 32-bit" enabled**.
+> Running in a 64-bit process will result in `REGDB_E_CLASSNOTREG` errors.
+> The `ComClientFactory.tryCreate` function performs an early check
+> and returns a clear error message if called from a 64-bit process.
 
 ```bash
 dotnet add package Xanthos
@@ -74,9 +82,10 @@ match service.FetchPayloads(request) with
 // Service and client are automatically disposed when leaving scope
 ```
 
-> **Resource Management:** `JvLinkService` implements `IDisposable` and takes ownership of the
-> `IJvLinkClient` passed to its constructor. Always use the `use` keyword or explicitly call
-> `Dispose()` to release COM resources and avoid STA thread leaks.
+> **Resource Management:** `JvLinkService` implements `IDisposable` and takes
+> ownership of the `IJvLinkClient` passed to its constructor.
+> Always use the `use` keyword or explicitly call `Dispose()` to release COM
+> resources and avoid STA thread leaks.
 
 ## Architecture
 
@@ -86,14 +95,16 @@ Xanthos follows a three-layer architecture:
 2. **Interop** (`Xanthos.Interop`) - COM interface implementations and test stubs
 3. **Runtime** (`Xanthos.Runtime`) - High-level service orchestration
 
-See [design/architecture/README.md](design/architecture/README.md) for detailed documentation.
+See [design/architecture/README.md](design/architecture/README.md) for detailed
+documentation.
 
 ## CLI Commands (E2E Coverage)
 
-All commands support global options: `--sid --service-key --save-path [--stub] [--diag]`.
+All commands support global options:
+`--sid --service-key --save-path [--stub] [--diag]`.
 
 | Command | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `version` | Show JV-Link version and evidence markers |
 | `download` | Bulk dataspec download & preview (optional persistence) |
 | `realtime` | Stream realtime payloads until end/cancel |
@@ -101,12 +112,18 @@ All commands support global options: `--sid --service-key --save-path [--stub] [
 | `skip` | Skip current file |
 | `cancel` | Cancel any active session |
 | `delete-file` | Delete a saved JV file by name |
-| `set-save-flag` / `get-save-flag` | Toggle/query persistence flag |
-| `set-save-path` / `get-save-path` | Configure/query save path |
-| `set-service-key` / `get-service-key` | Configure/query service key |
-| `set-payoff-dialog` / `get-payoff-dialog` | Suppress payoff dialogs |
-| `set-parent-hwnd` / `get-parent-hwnd` | Configure/query parent window handle (UI) |
-| `course-file` / `course-file2` | Retrieve course diagram (path + explanation / path only) |
+| `set-save-flag` | Enable/disable persistence flag |
+| `get-save-flag` | Show persistence flag |
+| `set-save-path` | Set save path |
+| `get-save-path` | Show save path |
+| `set-service-key` | Set service key |
+| `get-service-key` | Show service key |
+| `set-payoff-dialog` | Enable/disable payoff dialog suppression |
+| `get-payoff-dialog` | Show payoff dialog suppression |
+| `set-parent-hwnd` | Set parent window handle (UI) |
+| `get-parent-hwnd` | Show parent window handle (UI) |
+| `course-file` | Retrieve course diagram file path + explanation |
+| `course-file2` | Retrieve course diagram file path |
 | `silks-file` | Generate silks bitmap file |
 | `silks-binary` | Retrieve silks bytes |
 | `movie-check` | Check movie availability |
@@ -115,39 +132,62 @@ All commands support global options: `--sid --service-key --save-path [--stub] [
 | `movie-open` | Retrieve all workout video listings |
 | `help` | Show detailed usage text |
 
-> **Note:** The `status`, `skip`, and `cancel` commands require an active JVOpen session
-> in the same process. These commands query or control an ongoing download operation
-> and will return error code -203 if no session is open. In typical CLI usage, they are
-> only meaningful when called from the same long-running process that initiated a download.
+> **Note:** The `status`, `skip`, and `cancel` commands require an active JVOpen
+> session in the same process. These commands query or control an ongoing download
+> operation and will return error code -203 if no session is open.
+> In typical CLI usage, they are only meaningful when called from the same
+> long-running process that initiated a download.
 
 ### CLI Evidence Markers
 
 CLI output includes:
+
 - `EVIDENCE:MODE=COM|STUB`
 - `EVIDENCE:VERSION=<string>`
+
 Used by E2E tests to assert activation pathway and version retrieval logic.
 
 ## Streaming APIs
 
-- `StreamRealtimePayloads` (sync): handles `FileBoundary` (skips) and `DownloadPending` (incremental backoff) without breaking enumeration.
-- `StreamRealtimeAsync` (`IAsyncEnumerable`): cooperative cancellation; swallows `OperationCanceledException` and returns `false` from enumerator for graceful termination. The old `StreamRealtimePayloadsAsync` method name remains as a forwarding alias for backward compatibility.
-- Boundary tests cover consecutive `FileBoundary` markers and prolonged `DownloadPending` sequences.
+- `StreamRealtimePayloads` (sync): handles `FileBoundary` (skips) and `DownloadPending`
+  (incremental backoff) without breaking enumeration.
+- `StreamRealtimeAsync` (`IAsyncEnumerable`): cooperative cancellation; swallows
+  `OperationCanceledException` and returns `false` from enumerator
+  for graceful termination.
+  The old `StreamRealtimePayloadsAsync` method name remains as a forwarding alias
+  for backward compatibility.
+- Boundary tests cover consecutive `FileBoundary` markers and prolonged `DownloadPending`
+  sequences.
 
-> **Threading note:** The `*Async` methods return `IAsyncEnumerable` and support `await foreach`
-> semantics with cooperative cancellation between iterations. However, individual JV-Link COM
-> calls execute synchronously on the STA thread and will block the calling thread for their
-> duration. The async pattern enables cancellation checking and poll interval delays between
-> COM calls, not true non-blocking I/O. This is a fundamental limitation of COM interop.
-
-> **Heads-up:** `FetchPayloadsWithBytes` replaces the older `FetchPayloadsWithSize`. The legacy name still exists as an alias so existing callers keep working, but new code should prefer the clearer `*WithBytes` flavor.
+> **Threading note:** The `*Async` methods return `IAsyncEnumerable` and support
+> `await foreach` semantics with cooperative cancellation between iterations. However,
+> individual JV-Link COM calls execute synchronously on the STA thread and will
+> block the calling thread for their duration. The async pattern enables
+> cancellation checking and poll interval delays between COM calls, not true
+> non-blocking I/O.
+> This is a fundamental limitation of COM interop.
+> **Heads-up:** `FetchPayloadsWithBytes` replaces the older `FetchPayloadsWithSize`.
+> The legacy name still exists as an alias so existing callers keep working, but
+> new code should prefer the clearer `*WithBytes` flavor.
 
 ## Development Environment
 
 ### Native Diagnostics
 
-When you need to inspect the raw `IDispatch` surface or verify the actual JV-Link COM behaviour outside of .NET, refer to `design/notes/jvlink-early-binding.md` for the investigation summary. We confirmed that, despite the Type Library declaring `[out] BSTR*`, the COM server expects caller-managed buffers, so Xanthos intentionally sticks to late-bound invocation in production.
+When you need to inspect the raw `IDispatch` surface or verify the actual JV-Link
+COM behaviour outside of .NET, refer to `design/notes/jvlink-early-binding.md`
+for the investigation summary.
+We confirmed that, despite the Type Library declaring `[out] BSTR*`, the COM server
+expects caller-managed buffers, so Xanthos intentionally sticks to late-bound
+invocation in production.
 
-> **Note:** The `JVDTLab.JVLink` COM server exposes a Type Library that marks `JVRead` parameters as `[out] BSTR*`, but the actual implementation expects caller-managed buffers and does not accept the `IJVLink` early-bound interface generated from the Type Library. As a result, Xanthos intentionally relies on the late-bound `InvokeMember` path for `JVRead` (and related methods) and treats the type-safe `IJVLink` stubs as non-functional diagnostics only.
+> **Note:** The `JVDTLab.JVLink` COM server exposes a Type Library that marks `JVRead`
+> parameters as `[out] BSTR*`, but the actual implementation expects caller-managed
+> buffers and does not accept the `IJVLink` early-bound interface generated from
+> Type Library.
+> As a result, Xanthos intentionally relies on the late-bound `InvokeMember`
+> path for `JVRead` (and related methods) and treats the type-safe `IJVLink` stubs
+> as non-functional diagnostics only.
 
 ### Using Nix (Recommended)
 
@@ -159,28 +199,34 @@ This provides .NET SDK, Mono, and development tools with telemetry disabled.
 
 ### Manual Setup
 
-This project requires .NET 10.0 SDK (LTS). Follow these steps to install:
+This project requires the .NET 10 SDK. Follow these steps to install:
 
-**Windows (winget)**
+#### Windows (winget)
+
 ```powershell
 winget install Microsoft.DotNet.SDK.10
 ```
 
-**macOS (Homebrew)**
+#### macOS (Homebrew)
+
 ```bash
 brew install --cask dotnet-sdk
 ```
 
-**Linux / Manual Download**
-Download the .NET 10.0 SDK from the [.NET 10 downloads page](https://dotnet.microsoft.com/download/dotnet/10.0). Select your platform and follow the installation instructions.
+#### Linux / Manual Download
 
-**Verify Installation**
+Download the .NET 10 SDK from the [.NET 10 downloads page][dotnet-10-downloads].
+Select your platform and follow the installation instructions.
+
+#### Verify Installation
+
 ```bash
 dotnet --version
 # Should output 10.0.xxx
 ```
 
-> **Note**: If you have multiple .NET SDKs installed, you can use a `global.json` file to pin the SDK version. This project already includes one.
+> **Note**: If you have multiple .NET SDKs installed, you can use a `global.json`
+> file to pin the SDK version. This project already includes one.
 
 ## Code Formatting and Linting
 
@@ -202,9 +248,12 @@ dotnet fsdocs build --clean \
   --parameters \
     fsdocs-logo-src img/logo.png \
     fsdocs-favicon-src img/favicon.png \
-    fsdocs-license-link https://github.com/cariandrum22/Xanthos/blob/main/LICENSE \
-    fsdocs-release-notes-link https://github.com/cariandrum22/Xanthos/releases \
-    fsdocs-repository-link https://github.com/cariandrum22/Xanthos
+    fsdocs-license-link \
+      https://github.com/cariandrum22/Xanthos/blob/main/LICENSE \
+    fsdocs-release-notes-link \
+      https://github.com/cariandrum22/Xanthos/releases \
+    fsdocs-repository-link \
+      https://github.com/cariandrum22/Xanthos
 ```
 
 The generated site is output to `output/`. View with `dotnet fsdocs watch`.
@@ -232,18 +281,23 @@ dotnet test
 dotnet test tests/Xanthos.UnitTests
 
 # Run E2E tests in stub mode
-XANTHOS_E2E_MODE=STUB dotnet test tests/Xanthos.Cli.E2E
+XANTHOS_E2E_MODE=STUB \
+  dotnet test tests/Xanthos.Cli.E2E
 ```
 
 ### Test Structure
 
 | Project | Description | Platform |
-|---------|-------------|----------|
+| ------- | ----------- | -------- |
 | `Xanthos.UnitTests` | Unit tests with JvLinkStub | All |
 | `Xanthos.PropertyTests` | FsCheck property-based tests | All |
 | `Xanthos.Cli.E2E` | CLI end-to-end tests | All (Stub) / Windows (COM) |
 
-See `tests/README.md` for the naming conventions used across the unit-test suite (e.g., how `*ErrorTests` vs `*AbnormalTests` are scoped, and the preferred `Given/When/Then` style for test names). For CLI E2E test design and coverage details, see [design/tests/e2e-cli.md](design/tests/e2e-cli.md).
+See `tests/README.md` for the naming conventions used across the unit-test suite
+(e.g., how `*ErrorTests` vs `*AbnormalTests` are scoped, and the preferred
+`Given/When/Then` style for test names).
+For CLI E2E test design and coverage details, see
+[design/tests/e2e-cli.md](design/tests/e2e-cli.md).
 
 ### CI/CD
 
@@ -251,18 +305,20 @@ The project uses GitHub Actions for continuous integration:
 
 - **Build & Test**: Runs on Linux, macOS, and Windows
 - **E2E Tests**: Stub mode on all platforms; COM not required for CI
-- **Code Quality**: Format checking with `dotnet format`
+- **Code Quality**: Format checking with `dotnet fantomas --check .`
 - **Coverage**: Coverlet (cobertura & opencover) with ReportGenerator HTML summary
 
 See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for details.
 
 ### Windows COM Verification
 
-> **Note:** CI only validates stub mode. The actual COM layer cannot be tested in GitHub Actions
-> because JV-Link is a commercial product that requires local installation. Before each release,
-> manual verification on a Windows machine with JV-Link installed is required.
+> **Note:** CI only validates stub mode. The actual COM layer cannot be tested in
+> GitHub Actions because JV-Link is a commercial product that requires local
+> installation. Before each release, manual verification on a Windows machine with
+> JV-Link installed is required.
 
-Before tagging the initial release (and for any later COM regression), run the bundled PowerShell workflow on a Windows machine with JV-Link installed:
+Before tagging the initial release (and for any later COM regression), run the bundled
+PowerShell workflow on a Windows machine with JV-Link installed:
 
 ```powershell
 pwsh scripts/run-com-verification.ps1 `
@@ -277,26 +333,37 @@ pwsh scripts/run-com-verification.ps1 `
 Parameters:
 
 - `Sid` defaults to `UNKNOWN`; override with your actual SID.
-- `ServiceKey` is required (no default). You can also set `XANTHOS_E2E_SERVICE_KEY`.
-- `SavePath`, `Dataspec`, `FromTime`, `RealtimeKey`, and `WatchDurationSeconds` are optional overrides.
+- `ServiceKey` is required (no default).
+  You can also set `XANTHOS_E2E_SERVICE_KEY`.
+- `SavePath`, `Dataspec`, `FromTime`, and `RealtimeKey` are optional overrides.
+- `WatchDurationSeconds` is an optional override.
 - `-SkipBuild`, `-SkipTests`, or `-SkipCli` can be supplied for partial runs.
 
-The script performs `dotnet build`, `dotnet test` (with `XANTHOS_E2E_MODE=COM`), and a series of CLI commands (`version`, `status`, `download`, `watch-events`, optional `realtime`). Review the console output and CLI logs to confirm COM execution succeeded before shipping.
+The script performs `dotnet build`, `dotnet test` (with `XANTHOS_E2E_MODE=COM`),
+and a series of CLI commands (`version`, `status`, `download`, `watch-events`,
+optional `realtime`).
+Review the console output and CLI logs to confirm COM execution succeeded before
+shipping.
 
 ## Updating Error Catalog
 
-`src/Xanthos/Core/ErrorCatalog.fs` is generated from the official tables in `design/specs/error_codes.md`. If the specification changes, regenerate the catalog before building:
+`src/Xanthos/Core/ErrorCatalog.fs` is generated from the official tables in
+`design/specs/error_codes.md`.
+If the specification changes, regenerate the catalog before building:
 
 ```bash
 python3 scripts/generate_error_catalog.py
 ```
 
-Do not hand-edit the generated F# source; update the markdown spec and rerun the script.
+Do not hand-edit the generated F# source; update the markdown spec and rerun the
+script.
 
 ## COM vs Stub Mode
 
-- **Stub** mode (default in CI) guarantees deterministic responses; no JV-Link installation required.
-- **COM** mode (Windows only) can be used locally if JV-Link is installed and ProgID registered.
+- **Stub** mode (default in CI) guarantees deterministic responses; no JV-Link installation
+  required.
+- **COM** mode (Windows only) can be used locally if JV-Link is installed and
+  ProgID registered.
 - CLI outputs `EVIDENCE:MODE` so tests can assert which path executed.
 
 ## JV-Link Installation Check (Windows)
@@ -316,7 +383,18 @@ MIT License - see [LICENSE](LICENSE) for details.
 ## Contributing
 
 Contributions are welcome. Please:
+
 1. Fork & clone.
 2. Add tests for new record parsers or CLI commands.
 3. Regenerate the error catalog if you modify the spec.
 4. Ensure all tests pass in stub mode.
+
+[badge-ci]: https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml/badge.svg
+[badge-dotnet]: https://img.shields.io/badge/.NET-10.0-512BD4
+[badge-license]: https://img.shields.io/badge/License-MIT-yellow.svg
+[badge-nuget]: https://img.shields.io/nuget/v/Xanthos.svg
+[dotnet-10-downloads]: https://dotnet.microsoft.com/download/dotnet/10.0
+[link-ci]: https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml
+[link-dotnet]: https://dotnet.microsoft.com/
+[link-license]: https://opensource.org/licenses/MIT
+[link-nuget]: https://www.nuget.org/packages/Xanthos


### PR DESCRIPTION
## Summary

- Document the preferred merge strategy:
  - Topic branches -> `develop`: squash and merge
  - `develop` -> `main` (releases): merge commit
  - Rebase and merge: only for curated commit series
- Fix markdownlint warnings in `CONTRIBUTING.md`.
- Fix markdownlint warnings in `README.md`.
