### PR TITLE
chore(deps): update dependencies to latest stable versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-fsharplint": {
-      "version": "0.26.8",
+      "version": "0.26.10",
       "commands": [
         "dotnet-fsharplint"
       ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # General hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {

--- a/tests/Xanthos.Cli.E2E/Xanthos.Cli.E2E.fsproj
+++ b/tests/Xanthos.Cli.E2E/Xanthos.Cli.E2E.fsproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Xanthos.PropertyTests/Xanthos.PropertyTests.fsproj
+++ b/tests/Xanthos.PropertyTests/Xanthos.PropertyTests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="FsCheck" Version="3.3.2" />
     <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
+++ b/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
@@ -5,19 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="FsCheck" Version="2.16.6" />
     <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Update all outdated dependencies to their latest stable versions as of 2026-02-22.

- **coverlet.collector** 6.0.4 → 8.0.0
- **xunit.runner.visualstudio** 2.8.2 → 3.1.5 (all 3 test projects)
- **Xunit.SkippableFact** 1.4.13 → 1.5.61
- **dotnet-fsharplint** 0.26.8 → 0.26.10
- **pre-commit-hooks** v5.0.0 → v6.0.0
- **nixpkgs** 2025-11-17 → 2026-02-17 (`nix flake update`)

No code changes — only version bumps and lock file update.

## Test plan

- [x] `dotnet build` succeeds (0 warnings, 0 errors)
- [x] `dotnet test --filter UnitTests` — 940 passed, 13 skipped
- [x] `dotnet test --filter PropertyTests` — 29 passed
- [x] Windows E2E tests pass