### PR TITLE
chore(deps): migrate UnitTests FsCheck v2 to v3

### DIFF
--- a/tests/Xanthos.UnitTests/PropertyTests.fs
+++ b/tests/Xanthos.UnitTests/PropertyTests.fs
@@ -2,6 +2,7 @@ module Xanthos.UnitTests.PropertyTests
 
 open System
 open FsCheck
+open FsCheck.FSharp
 open FsCheck.Xunit
 open Xanthos.Core
 open Xanthos.Core.Text
@@ -40,8 +41,10 @@ let horseIdGen =
     }
 
 /// Generate valid byte arrays with specific size
+let private defaults = ArbMap.defaults
+
 let byteArrayGen size =
-    Gen.arrayOfLength size Arb.generate<byte>
+    Gen.arrayOfLength size (ArbMap.generate<byte> defaults)
 
 // ============================================================================
 // Property-Based Tests for RecordParser Core Functions

--- a/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
+++ b/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
@@ -15,8 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="FsCheck" Version="2.16.6" />
-    <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
+    <PackageReference Include="FsCheck" Version="3.3.2" />
+    <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Upgrade FsCheck 2.16.6 → 3.3.2 and FsCheck.Xunit 2.16.6 → 3.3.2 (UnitTests only)
- Align with PropertyTests which already uses FsCheck v3
- Migrate removed v2 API (`Arb.generate<T>`) to v3 equivalent (`ArbMap.generate<T>`)

## Changes

- `Xanthos.UnitTests.fsproj`: Bump FsCheck / FsCheck.Xunit to 3.3.2
- `PropertyTests.fs`: Add `open FsCheck.FSharp`, replace `Arb.generate<byte>` with `ArbMap.generate<byte> defaults`

## Test plan

- [x] `dotnet build` succeeds (0 warnings, 0 errors)
- [x] UnitTests: 940 passed (Linux)
- [x] PropertyTests: 29 passed (Linux)
- [x] Windows full test suite: 1022 passed