### PR TITLE
Release v0.2.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-fsharplint": {
-      "version": "0.26.8",
+      "version": "0.26.10",
       "commands": [
         "dotnet-fsharplint"
       ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # General hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
 - Avoid unsupported COM property access for `ParentHWnd` (write-only) and `m_payflag` (read-only); return clear `Unsupported` errors from `JvLinkService` in COM mode ([#14](https://github.com/cariandrum22/Xanthos/issues/14))
+- Improve CLI E2E harness diagnostics for exe-mode builds on Windows ([#17](https://github.com/cariandrum22/Xanthos/issues/17))
 
 ## [0.1.0] - 2025-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Xanthos will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
+  - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
+
 ## [0.1.0] - 2025-12-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
 
+### Fixed
+
+- Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
+
 ## [0.1.0] - 2025-12-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
 - Make `IJvLinkClient.ServiceKey` property read-only ([#5](https://github.com/cariandrum22/Xanthos/issues/5))
   - Per JV-Link specification: `ServiceKey` can only be set via `SetServiceKeyDirect` method
+- Change default JVRead/JVGets behavior: use JVGets by default; set `XANTHOS_USE_JVREAD=1` to opt out ([#3](https://github.com/cariandrum22/Xanthos/issues/3))
+  - `XANTHOS_USE_JVGETS` is still supported as a legacy override
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
+- Avoid unsupported COM property access for `ParentHWnd` (write-only) and `m_payflag` (read-only); return clear `Unsupported` errors from `JvLinkService` in COM mode ([#14](https://github.com/cariandrum22/Xanthos/issues/14))
 
 ## [0.1.0] - 2025-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
   - Per JV-Link specification: `SavePath` can only be set via `SetSavePathDirect` method
+- Make `IJvLinkClient.ServiceKey` property read-only ([#5](https://github.com/cariandrum22/Xanthos/issues/5))
+  - Per JV-Link specification: `ServiceKey` can only be set via `SetServiceKeyDirect` method
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-22
+
 ### Breaking Changes
 
 - Make `IJvLinkClient.SavePath` property read-only ([#1](https://github.com/cariandrum22/Xanthos/issues/1), [#4](https://github.com/cariandrum22/Xanthos/pull/4))
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce excessive diagnostic logging in `checkUseJvGets()` by caching the resolved value ([#2](https://github.com/cariandrum22/Xanthos/issues/2))
 - Avoid unsupported COM property access for `ParentHWnd` (write-only) and `m_payflag` (read-only); return clear `Unsupported` errors from `JvLinkService` in COM mode ([#14](https://github.com/cariandrum22/Xanthos/issues/14))
 - Improve CLI E2E harness diagnostics for exe-mode builds on Windows ([#17](https://github.com/cariandrum22/Xanthos/issues/17))
+- Fix CLI mojibake for Japanese text when stdout is redirected ([#19](https://github.com/cariandrum22/Xanthos/issues/19))
 
 ## [0.1.0] - 2025-12-10
 
@@ -47,4 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error catalog generated from JV-Link specifications
 - API documentation with fsdocs
 
+[0.2.0]: https://github.com/cariandrum22/Xanthos/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/cariandrum22/Xanthos/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Xanthos
 
-Thank you for your interest in contributing to Xanthos! This document explains how to contribute to the project.
+Thank you for your interest in contributing to Xanthos!
+This document explains how to contribute to the project.
 
 ## Development Environment Setup
 
@@ -38,7 +39,7 @@ dotnet test
 
 This project follows a GitFlow-like branching strategy.
 
-```
+```text
 main (release branch)
   ↑ On merge: version increment + CHANGELOG finalization
 develop (development branch)
@@ -47,13 +48,14 @@ feature/*, fix/* (topic branches)
 ```
 
 | Branch | Purpose | Merge Target |
-|--------|---------|--------------|
+| ------ | ------- | ------------ |
 | `main` | Stable releases. Published to NuGet | - |
 | `develop` | Development integration. Next release candidate | `main` |
 | `feature/*` | New feature development | `develop` |
 | `fix/*` | Bug fixes | `develop` |
 
 **Important**:
+
 - Topic branches are created from `develop` and merged back to `develop`
 - Merging to `main` is only done during releases
 - Direct commits to `main` are prohibited
@@ -63,11 +65,13 @@ feature/*, fix/* (topic branches)
 Use a consistent, descriptive branch name format:
 
 - **With an Issue**: `<type>/<issue-number>-<slug>`
-- **Without an Issue**: `<type>/<slug>` (or `<type>/no-issue-<slug>` if you want to make that explicit)
+- **Without an Issue**: `<type>/<slug>`
+  (or `<type>/no-issue-<slug>` if you want to make that explicit)
 
 Rules:
 
-- `type` should align with Conventional Commits types (e.g. `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `ci/`, `chore/`)
+- `type` should align with Conventional Commits types (e.g. `feat/`, `fix/`, `docs/`,
+  `refactor/`, `test/`, `ci/`, `chore/`)
 - `issue-number` is digits only (no `issue-` prefix)
 - `slug` should be short, kebab-case, and descriptive
 
@@ -87,9 +91,10 @@ Examples:
 
 ### Commit Messages
 
-This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+specification.
 
-```
+```text
 <type>[optional scope]: <description>
 
 [optional body]
@@ -100,7 +105,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 **Types:**
 
 | Type | Description | SemVer |
-|------|-------------|--------|
+| ---- | ----------- | ----- |
 | `feat` | New feature | MINOR |
 | `fix` | Bug fix | PATCH |
 | `docs` | Documentation only | - |
@@ -116,7 +121,7 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 
 Append `!` after type/scope or add `BREAKING CHANGE:` in footer:
 
-```
+```text
 feat!: remove deprecated API
 
 BREAKING CHANGE: The old API has been removed.
@@ -124,7 +129,7 @@ BREAKING CHANGE: The old API has been removed.
 
 **Examples:**
 
-```
+```text
 feat: add realtime data streaming support
 fix: correct SavePath property access
 docs: update installation instructions
@@ -168,7 +173,7 @@ dotnet fsharplint lint src tests
 ### Test Categories
 
 | Category | Description | Environment |
-|----------|-------------|-------------|
+| -------- | ----------- | ----------- |
 | Unit | Pure F# unit tests | CI (any OS) |
 | Property | FsCheck property-based tests | CI (any OS) |
 | Fixtures | Fixture-based parser tests | CI (if fixtures exist) |
@@ -201,7 +206,8 @@ XANTHOS_E2E_MODE=COM XANTHOS_SID=YOUR_SID dotnet test tests/Xanthos.Cli.E2E
 ### Manual COM Verification
 
 Some functionality requires testing with real JV-Link COM on Windows.
-See [tests/README.md - Manual COM Verification](tests/README.md#manual-com-verification) for:
+See [tests/README.md - Manual COM Verification](tests/README.md#manual-com-verification)
+for:
 
 - Step-by-step verification procedures
 - Pre-release checklist template
@@ -250,6 +256,16 @@ Brief description of changes
 - [ ] CHANGELOG.md updated
 ```
 
+### Merge Strategy
+
+To keep the `develop` history readable and consistent:
+
+- **Topic branches → `develop`**: prefer **Squash and merge** (one PR = one commit).
+- **`develop` → `main` (releases)**: prefer a **merge commit** to preserve a clear
+  release boundary.
+- **Rebase and merge**: only use when each commit is intentionally curated and
+  meaningful on its own.
+
 ## Architecture
 
 The project follows a three-layer architecture:
@@ -287,6 +303,7 @@ When merging a PR, add changes to the `[Unreleased]` section in `CHANGELOG.md`:
 ```
 
 Categories:
+
 - **Added**: New features
 - **Changed**: Changes to existing features
 - **Deprecated**: Features that are deprecated
@@ -318,7 +335,8 @@ Versions are centrally managed in `Directory.Build.props`.
 Before tagging a release, complete the following:
 
 1. **CI Tests**: All GitHub Actions workflows pass
-2. **Manual COM Verification**: Complete the [verification checklist](tests/README.md#verification-checklist) on Windows
+2. **Manual COM Verification**: Complete the
+   [verification checklist](tests/README.md#verification-checklist) on Windows
 3. **CHANGELOG**: Finalize `[Unreleased]` section with release version
 4. **Version**: Update version in `Directory.Build.props`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,29 @@ dotnet test
 
 ## Development Workflow
 
-### Branch Strategy
+### Branch Strategy (GitFlow)
 
-- `main` - Stable releases
-- `develop` - Development branch
-- `feature/*` - New features
-- `fix/*` - Bug fixes
+This project follows a GitFlow-like branching strategy.
+
+```
+main (release branch)
+  ↑ On merge: version increment + CHANGELOG finalization
+develop (development branch)
+  ↑ PR merge
+feature/*, fix/* (topic branches)
+```
+
+| Branch | Purpose | Merge Target |
+|--------|---------|--------------|
+| `main` | Stable releases. Published to NuGet | - |
+| `develop` | Development integration. Next release candidate | `main` |
+| `feature/*` | New feature development | `develop` |
+| `fix/*` | Bug fixes | `develop` |
+
+**Important**:
+- Topic branches are created from `develop` and merged back to `develop`
+- Merging to `main` is only done during releases
+- Direct commits to `main` are prohibited
 
 ### Contribution Process
 
@@ -51,21 +68,50 @@ dotnet test
 
 ### Commit Messages
 
-Use clear and concise commit messages:
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 
 ```
-<type>: <summary>
+<type>[optional scope]: <description>
 
-<body (optional)>
+[optional body]
+
+[optional footer(s)]
 ```
 
-Types:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation
-- `test`: Tests
-- `refactor`: Refactoring
-- `ci`: CI/CD
+**Types:**
+
+| Type | Description | SemVer |
+|------|-------------|--------|
+| `feat` | New feature | MINOR |
+| `fix` | Bug fix | PATCH |
+| `docs` | Documentation only | - |
+| `style` | Formatting (no code change) | - |
+| `refactor` | Code refactoring | - |
+| `perf` | Performance improvement | - |
+| `test` | Adding/fixing tests | - |
+| `build` | Build system changes | - |
+| `ci` | CI/CD changes | - |
+| `chore` | Other maintenance | - |
+
+**Breaking Changes:**
+
+Append `!` after type/scope or add `BREAKING CHANGE:` in footer:
+
+```
+feat!: remove deprecated API
+
+BREAKING CHANGE: The old API has been removed.
+```
+
+**Examples:**
+
+```
+feat: add realtime data streaming support
+fix: correct SavePath property access
+docs: update installation instructions
+refactor(parser): simplify record parsing logic
+feat(cli)!: change command argument format
+```
 
 ## Coding Conventions
 
@@ -197,14 +243,65 @@ See [design/architecture/README.md](design/architecture/README.md) for details.
 
 ## Releases
 
+### CHANGELOG Management
+
+This project follows the [Keep a Changelog](https://keepachangelog.com/) format.
+
+#### Recording Changes During Development
+
+When merging a PR, add changes to the `[Unreleased]` section in `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added
+- Description of new feature
+
+### Changed
+- Description of changes
+
+### Fixed
+- Description of fix
+
+### Breaking Changes
+- Description of breaking change (interface changes, etc.)
+```
+
+Categories:
+- **Added**: New features
+- **Changed**: Changes to existing features
+- **Deprecated**: Features that are deprecated
+- **Removed**: Features that were removed
+- **Fixed**: Bug fixes
+- **Security**: Security fixes
+- **Breaking Changes**: Breaking changes (API/interface changes)
+
+#### Finalizing CHANGELOG on Release
+
+When merging `develop` → `main`:
+
+1. Change `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`
+2. Add a new empty `[Unreleased]` section
+3. Update version comparison links
+
+### Version Management
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR**: Breaking changes (interface changes, etc.)
+- **MINOR**: Backward-compatible new features
+- **PATCH**: Backward-compatible bug fixes
+
+Versions are centrally managed in `Directory.Build.props`.
+
 ### Pre-Release Checklist
 
 Before tagging a release, complete the following:
 
 1. **CI Tests**: All GitHub Actions workflows pass
 2. **Manual COM Verification**: Complete the [verification checklist](tests/README.md#verification-checklist) on Windows
-3. **CHANGELOG**: Update with release notes
-4. **Version**: Update version numbers as needed
+3. **CHANGELOG**: Finalize `[Unreleased]` section with release version
+4. **Version**: Update version in `Directory.Build.props`
 
 ### Release Verification Evidence
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,25 @@ feature/*, fix/* (topic branches)
 - Merging to `main` is only done during releases
 - Direct commits to `main` are prohibited
 
+### Branch Naming
+
+Use a consistent, descriptive branch name format:
+
+- **With an Issue**: `<type>/<issue-number>-<slug>`
+- **Without an Issue**: `<type>/<slug>` (or `<type>/no-issue-<slug>` if you want to make that explicit)
+
+Rules:
+
+- `type` should align with Conventional Commits types (e.g. `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `ci/`, `chore/`)
+- `issue-number` is digits only (no `issue-` prefix)
+- `slug` should be short, kebab-case, and descriptive
+
+Examples:
+
+- `fix/3-jvgets-default`
+- `docs/6-gitflow-workflow`
+- `chore/no-issue-ci-cleanup`
+
 ### Contribution Process
 
 1. Create an Issue to discuss changes (for major changes)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,11 @@ XANTHOS_E2E_MODE=STUB \
   dotnet test tests/Xanthos.Cli.E2E
 ```
 
+### Text Encoding
+
+- **In-memory**: Xanthos represents text as Unicode `string` (UTF-16).
+- **CLI / logs**: `samples/Xanthos.Cli` configures stdout/stderr as UTF-8 (no BOM) to keep Japanese output readable in redirected logs and test harnesses.
+
 ### Test Structure
 
 | Project | Description | Platform |

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ All commands support global options: `--sid --service-key --save-path [--stub] [
 | `set-save-flag` / `get-save-flag` | Toggle/query persistence flag |
 | `set-save-path` / `get-save-path` | Configure/query save path |
 | `set-service-key` / `get-service-key` | Configure/query service key |
-| `set-payoff-dialog` / `get-payoff-dialog` | Suppress payoff dialogs |
-| `set-parent-hwnd` / `get-parent-hwnd` | Configure/query parent window handle (UI) |
+| `set-payoff-dialog` / `get-payoff-dialog` | Query payoff dialog suppression (`set-payoff-dialog` is not supported in COM; use `set-ui-properties`) |
+| `set-parent-hwnd` / `get-parent-hwnd` | Configure/query parent window handle (`get-parent-hwnd` is not supported in COM; `ParentHWnd` is write-only) |
 | `course-file` / `course-file2` | Retrieve course diagram (path + explanation / path only) |
 | `silks-file` | Generate silks bitmap file |
 | `silks-binary` | Retrieve silks bytes |

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
 # Xanthos
 
-[![CI](https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml/badge.svg)](https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml)
-[![NuGet](https://img.shields.io/nuget/v/Xanthos.svg)](https://www.nuget.org/packages/Xanthos)
-[![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI][badge-ci]][link-ci]
+[![NuGet][badge-nuget]][link-nuget]
+[![.NET][badge-dotnet]][link-dotnet]
+[![License: MIT][badge-license]][link-license]
 
 F# wrapper library for the JRA-VAN Data Lab. JV-Link COM API.
 
 ## Overview
 
-Xanthos provides a type-safe, modern F# interface to the legacy JV-Link ActiveX COM component. It leverages F#'s powerful type system to model the JRA-VAN API safely, converting COM exceptions and error codes into idiomatic `Result<'T, Error>` workflows.
+Xanthos provides a type-safe, modern F# interface to the legacy JV-Link ActiveX
+COM component. It leverages F#'s powerful type system to model the JRA-VAN API safely,
+converting COM exceptions and error codes into idiomatic `Result<'T, Error>` workflows.
 
 ### Features
 
 - **Type-safe API**: Discriminated unions and records model JV-Link data structures
 - **Error handling**: COM errors mapped to F# Result types
 - **Streaming support**: AsyncSeq-based streaming for large data sets
-- **Cross-platform development**: Core logic runs on any .NET platform; COM interop requires Windows
-- **Stub mode**: Deterministic `JvLinkStub` enables full testability in CI where COM is unavailable
+- **Cross-platform development**: Core logic runs on any .NET platform
+  (COM interop requires Windows)
+- **Stub mode**: Deterministic `JvLinkStub` enables full testability in CI
+  where COM is unavailable
 - **CLI tooling**: Rich command surface with E2E coverage in stub mode
 
 ## Installation
 
-> **Requirements**: .NET 10 SDK. COM interop functionality is only available on Windows.
+> **Requirements**: .NET 10 SDK. COM interop functionality is only available on
+> Windows.
 >
-> **Important (Windows COM mode):** JV-Link COM server is a 32-bit (x86) component and only works
-> in 32-bit processes. When using `ComJvLinkClient`, your application must target **x86** or use
-> **AnyCPU with "Prefer 32-bit" enabled**. Running in a 64-bit process will result in
-> `REGDB_E_CLASSNOTREG` errors. The `ComClientFactory.tryCreate` function performs an early
-> check and returns a clear error message if called from a 64-bit process.
+> **Important (Windows COM mode):**
+> JV-Link COM server is a 32-bit (x86) component and only works in 32-bit
+> processes.
+> When using `ComJvLinkClient`, your application must target **x86** or use
+> **AnyCPU with "Prefer 32-bit" enabled**.
+> Running in a 64-bit process will result in `REGDB_E_CLASSNOTREG` errors.
+> The `ComClientFactory.tryCreate` function performs an early check
+> and returns a clear error message if called from a 64-bit process.
 
 ```bash
 dotnet add package Xanthos
@@ -74,9 +82,10 @@ match service.FetchPayloads(request) with
 // Service and client are automatically disposed when leaving scope
 ```
 
-> **Resource Management:** `JvLinkService` implements `IDisposable` and takes ownership of the
-> `IJvLinkClient` passed to its constructor. Always use the `use` keyword or explicitly call
-> `Dispose()` to release COM resources and avoid STA thread leaks.
+> **Resource Management:** `JvLinkService` implements `IDisposable` and takes
+> ownership of the `IJvLinkClient` passed to its constructor.
+> Always use the `use` keyword or explicitly call `Dispose()` to release COM
+> resources and avoid STA thread leaks.
 
 ## Architecture
 
@@ -86,14 +95,16 @@ Xanthos follows a three-layer architecture:
 2. **Interop** (`Xanthos.Interop`) - COM interface implementations and test stubs
 3. **Runtime** (`Xanthos.Runtime`) - High-level service orchestration
 
-See [design/architecture/README.md](design/architecture/README.md) for detailed documentation.
+See [design/architecture/README.md](design/architecture/README.md) for detailed
+documentation.
 
 ## CLI Commands (E2E Coverage)
 
-All commands support global options: `--sid --service-key --save-path [--stub] [--diag]`.
+All commands support global options:
+`--sid --service-key --save-path [--stub] [--diag]`.
 
 | Command | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `version` | Show JV-Link version and evidence markers |
 | `download` | Bulk dataspec download & preview (optional persistence) |
 | `realtime` | Stream realtime payloads until end/cancel |
@@ -101,12 +112,18 @@ All commands support global options: `--sid --service-key --save-path [--stub] [
 | `skip` | Skip current file |
 | `cancel` | Cancel any active session |
 | `delete-file` | Delete a saved JV file by name |
-| `set-save-flag` / `get-save-flag` | Toggle/query persistence flag |
-| `set-save-path` / `get-save-path` | Configure/query save path |
-| `set-service-key` / `get-service-key` | Configure/query service key |
-| `set-payoff-dialog` / `get-payoff-dialog` | Query payoff dialog suppression (`set-payoff-dialog` is not supported in COM; use `set-ui-properties`) |
-| `set-parent-hwnd` / `get-parent-hwnd` | Configure/query parent window handle (`get-parent-hwnd` is not supported in COM; `ParentHWnd` is write-only) |
-| `course-file` / `course-file2` | Retrieve course diagram (path + explanation / path only) |
+| `set-save-flag` | Enable/disable persistence flag |
+| `get-save-flag` | Show persistence flag |
+| `set-save-path` | Set save path |
+| `get-save-path` | Show save path |
+| `set-service-key` | Set service key |
+| `get-service-key` | Show service key |
+| `set-payoff-dialog` | Set payoff dialog suppression (COM: use `set-ui-properties`) |
+| `get-payoff-dialog` | Show payoff dialog suppression |
+| `set-parent-hwnd` | Set parent window handle (UI) |
+| `get-parent-hwnd` | Show parent window handle (COM: unsupported; `ParentHWnd` is write-only) |
+| `course-file` | Retrieve course diagram file path + explanation |
+| `course-file2` | Retrieve course diagram file path |
 | `silks-file` | Generate silks bitmap file |
 | `silks-binary` | Retrieve silks bytes |
 | `movie-check` | Check movie availability |
@@ -115,39 +132,62 @@ All commands support global options: `--sid --service-key --save-path [--stub] [
 | `movie-open` | Retrieve all workout video listings |
 | `help` | Show detailed usage text |
 
-> **Note:** The `status`, `skip`, and `cancel` commands require an active JVOpen session
-> in the same process. These commands query or control an ongoing download operation
-> and will return error code -203 if no session is open. In typical CLI usage, they are
-> only meaningful when called from the same long-running process that initiated a download.
+> **Note:** The `status`, `skip`, and `cancel` commands require an active JVOpen
+> session in the same process. These commands query or control an ongoing download
+> operation and will return error code -203 if no session is open.
+> In typical CLI usage, they are only meaningful when called from the same
+> long-running process that initiated a download.
 
 ### CLI Evidence Markers
 
 CLI output includes:
+
 - `EVIDENCE:MODE=COM|STUB`
 - `EVIDENCE:VERSION=<string>`
+
 Used by E2E tests to assert activation pathway and version retrieval logic.
 
 ## Streaming APIs
 
-- `StreamRealtimePayloads` (sync): handles `FileBoundary` (skips) and `DownloadPending` (incremental backoff) without breaking enumeration.
-- `StreamRealtimeAsync` (`IAsyncEnumerable`): cooperative cancellation; swallows `OperationCanceledException` and returns `false` from enumerator for graceful termination. The old `StreamRealtimePayloadsAsync` method name remains as a forwarding alias for backward compatibility.
-- Boundary tests cover consecutive `FileBoundary` markers and prolonged `DownloadPending` sequences.
+- `StreamRealtimePayloads` (sync): handles `FileBoundary` (skips) and `DownloadPending`
+  (incremental backoff) without breaking enumeration.
+- `StreamRealtimeAsync` (`IAsyncEnumerable`): cooperative cancellation; swallows
+  `OperationCanceledException` and returns `false` from enumerator
+  for graceful termination.
+  The old `StreamRealtimePayloadsAsync` method name remains as a forwarding alias
+  for backward compatibility.
+- Boundary tests cover consecutive `FileBoundary` markers and prolonged `DownloadPending`
+  sequences.
 
-> **Threading note:** The `*Async` methods return `IAsyncEnumerable` and support `await foreach`
-> semantics with cooperative cancellation between iterations. However, individual JV-Link COM
-> calls execute synchronously on the STA thread and will block the calling thread for their
-> duration. The async pattern enables cancellation checking and poll interval delays between
-> COM calls, not true non-blocking I/O. This is a fundamental limitation of COM interop.
-
-> **Heads-up:** `FetchPayloadsWithBytes` replaces the older `FetchPayloadsWithSize`. The legacy name still exists as an alias so existing callers keep working, but new code should prefer the clearer `*WithBytes` flavor.
+> **Threading note:** The `*Async` methods return `IAsyncEnumerable` and support
+> `await foreach` semantics with cooperative cancellation between iterations. However,
+> individual JV-Link COM calls execute synchronously on the STA thread and will
+> block the calling thread for their duration. The async pattern enables
+> cancellation checking and poll interval delays between COM calls, not true
+> non-blocking I/O.
+> This is a fundamental limitation of COM interop.
+> **Heads-up:** `FetchPayloadsWithBytes` replaces the older `FetchPayloadsWithSize`.
+> The legacy name still exists as an alias so existing callers keep working, but
+> new code should prefer the clearer `*WithBytes` flavor.
 
 ## Development Environment
 
 ### Native Diagnostics
 
-When you need to inspect the raw `IDispatch` surface or verify the actual JV-Link COM behaviour outside of .NET, refer to `design/notes/jvlink-early-binding.md` for the investigation summary. We confirmed that, despite the Type Library declaring `[out] BSTR*`, the COM server expects caller-managed buffers, so Xanthos intentionally sticks to late-bound invocation in production.
+When you need to inspect the raw `IDispatch` surface or verify the actual JV-Link
+COM behaviour outside of .NET, refer to `design/notes/jvlink-early-binding.md`
+for the investigation summary.
+We confirmed that, despite the Type Library declaring `[out] BSTR*`, the COM server
+expects caller-managed buffers, so Xanthos intentionally sticks to late-bound
+invocation in production.
 
-> **Note:** The `JVDTLab.JVLink` COM server exposes a Type Library that marks `JVRead` parameters as `[out] BSTR*`, but the actual implementation expects caller-managed buffers and does not accept the `IJVLink` early-bound interface generated from the Type Library. As a result, Xanthos intentionally relies on the late-bound `InvokeMember` path for `JVRead` (and related methods) and treats the type-safe `IJVLink` stubs as non-functional diagnostics only.
+> **Note:** The `JVDTLab.JVLink` COM server exposes a Type Library that marks `JVRead`
+> parameters as `[out] BSTR*`, but the actual implementation expects caller-managed
+> buffers and does not accept the `IJVLink` early-bound interface generated from
+> Type Library.
+> As a result, Xanthos intentionally relies on the late-bound `InvokeMember`
+> path for `JVRead` (and related methods) and treats the type-safe `IJVLink` stubs
+> as non-functional diagnostics only.
 
 ### Using Nix (Recommended)
 
@@ -159,28 +199,34 @@ This provides .NET SDK, Mono, and development tools with telemetry disabled.
 
 ### Manual Setup
 
-This project requires .NET 10.0 SDK (LTS). Follow these steps to install:
+This project requires the .NET 10 SDK. Follow these steps to install:
 
-**Windows (winget)**
+#### Windows (winget)
+
 ```powershell
 winget install Microsoft.DotNet.SDK.10
 ```
 
-**macOS (Homebrew)**
+#### macOS (Homebrew)
+
 ```bash
 brew install --cask dotnet-sdk
 ```
 
-**Linux / Manual Download**
-Download the .NET 10.0 SDK from the [.NET 10 downloads page](https://dotnet.microsoft.com/download/dotnet/10.0). Select your platform and follow the installation instructions.
+#### Linux / Manual Download
 
-**Verify Installation**
+Download the .NET 10 SDK from the [.NET 10 downloads page][dotnet-10-downloads].
+Select your platform and follow the installation instructions.
+
+#### Verify Installation
+
 ```bash
 dotnet --version
 # Should output 10.0.xxx
 ```
 
-> **Note**: If you have multiple .NET SDKs installed, you can use a `global.json` file to pin the SDK version. This project already includes one.
+> **Note**: If you have multiple .NET SDKs installed, you can use a `global.json`
+> file to pin the SDK version. This project already includes one.
 
 ## Code Formatting and Linting
 
@@ -202,9 +248,12 @@ dotnet fsdocs build --clean \
   --parameters \
     fsdocs-logo-src img/logo.png \
     fsdocs-favicon-src img/favicon.png \
-    fsdocs-license-link https://github.com/cariandrum22/Xanthos/blob/main/LICENSE \
-    fsdocs-release-notes-link https://github.com/cariandrum22/Xanthos/releases \
-    fsdocs-repository-link https://github.com/cariandrum22/Xanthos
+    fsdocs-license-link \
+      https://github.com/cariandrum22/Xanthos/blob/main/LICENSE \
+    fsdocs-release-notes-link \
+      https://github.com/cariandrum22/Xanthos/releases \
+    fsdocs-repository-link \
+      https://github.com/cariandrum22/Xanthos
 ```
 
 The generated site is output to `output/`. View with `dotnet fsdocs watch`.
@@ -232,18 +281,23 @@ dotnet test
 dotnet test tests/Xanthos.UnitTests
 
 # Run E2E tests in stub mode
-XANTHOS_E2E_MODE=STUB dotnet test tests/Xanthos.Cli.E2E
+XANTHOS_E2E_MODE=STUB \
+  dotnet test tests/Xanthos.Cli.E2E
 ```
 
 ### Test Structure
 
 | Project | Description | Platform |
-|---------|-------------|----------|
+| ------- | ----------- | -------- |
 | `Xanthos.UnitTests` | Unit tests with JvLinkStub | All |
 | `Xanthos.PropertyTests` | FsCheck property-based tests | All |
 | `Xanthos.Cli.E2E` | CLI end-to-end tests | All (Stub) / Windows (COM) |
 
-See `tests/README.md` for the naming conventions used across the unit-test suite (e.g., how `*ErrorTests` vs `*AbnormalTests` are scoped, and the preferred `Given/When/Then` style for test names). For CLI E2E test design and coverage details, see [design/tests/e2e-cli.md](design/tests/e2e-cli.md).
+See `tests/README.md` for the naming conventions used across the unit-test suite
+(e.g., how `*ErrorTests` vs `*AbnormalTests` are scoped, and the preferred
+`Given/When/Then` style for test names).
+For CLI E2E test design and coverage details, see
+[design/tests/e2e-cli.md](design/tests/e2e-cli.md).
 
 ### CI/CD
 
@@ -251,18 +305,20 @@ The project uses GitHub Actions for continuous integration:
 
 - **Build & Test**: Runs on Linux, macOS, and Windows
 - **E2E Tests**: Stub mode on all platforms; COM not required for CI
-- **Code Quality**: Format checking with `dotnet format`
+- **Code Quality**: Format checking with `dotnet fantomas --check .`
 - **Coverage**: Coverlet (cobertura & opencover) with ReportGenerator HTML summary
 
 See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for details.
 
 ### Windows COM Verification
 
-> **Note:** CI only validates stub mode. The actual COM layer cannot be tested in GitHub Actions
-> because JV-Link is a commercial product that requires local installation. Before each release,
-> manual verification on a Windows machine with JV-Link installed is required.
+> **Note:** CI only validates stub mode. The actual COM layer cannot be tested in
+> GitHub Actions because JV-Link is a commercial product that requires local
+> installation. Before each release, manual verification on a Windows machine with
+> JV-Link installed is required.
 
-Before tagging the initial release (and for any later COM regression), run the bundled PowerShell workflow on a Windows machine with JV-Link installed:
+Before tagging the initial release (and for any later COM regression), run the bundled
+PowerShell workflow on a Windows machine with JV-Link installed:
 
 ```powershell
 pwsh scripts/run-com-verification.ps1 `
@@ -277,26 +333,37 @@ pwsh scripts/run-com-verification.ps1 `
 Parameters:
 
 - `Sid` defaults to `UNKNOWN`; override with your actual SID.
-- `ServiceKey` is required (no default). You can also set `XANTHOS_E2E_SERVICE_KEY`.
-- `SavePath`, `Dataspec`, `FromTime`, `RealtimeKey`, and `WatchDurationSeconds` are optional overrides.
+- `ServiceKey` is required (no default).
+  You can also set `XANTHOS_E2E_SERVICE_KEY`.
+- `SavePath`, `Dataspec`, `FromTime`, and `RealtimeKey` are optional overrides.
+- `WatchDurationSeconds` is an optional override.
 - `-SkipBuild`, `-SkipTests`, or `-SkipCli` can be supplied for partial runs.
 
-The script performs `dotnet build`, `dotnet test` (with `XANTHOS_E2E_MODE=COM`), and a series of CLI commands (`version`, `status`, `download`, `watch-events`, optional `realtime`). Review the console output and CLI logs to confirm COM execution succeeded before shipping.
+The script performs `dotnet build`, `dotnet test` (with `XANTHOS_E2E_MODE=COM`),
+and a series of CLI commands (`version`, `status`, `download`, `watch-events`,
+optional `realtime`).
+Review the console output and CLI logs to confirm COM execution succeeded before
+shipping.
 
 ## Updating Error Catalog
 
-`src/Xanthos/Core/ErrorCatalog.fs` is generated from the official tables in `design/specs/error_codes.md`. If the specification changes, regenerate the catalog before building:
+`src/Xanthos/Core/ErrorCatalog.fs` is generated from the official tables in
+`design/specs/error_codes.md`.
+If the specification changes, regenerate the catalog before building:
 
 ```bash
 python3 scripts/generate_error_catalog.py
 ```
 
-Do not hand-edit the generated F# source; update the markdown spec and rerun the script.
+Do not hand-edit the generated F# source; update the markdown spec and rerun the
+script.
 
 ## COM vs Stub Mode
 
-- **Stub** mode (default in CI) guarantees deterministic responses; no JV-Link installation required.
-- **COM** mode (Windows only) can be used locally if JV-Link is installed and ProgID registered.
+- **Stub** mode (default in CI) guarantees deterministic responses; no JV-Link installation
+  required.
+- **COM** mode (Windows only) can be used locally if JV-Link is installed and
+  ProgID registered.
 - CLI outputs `EVIDENCE:MODE` so tests can assert which path executed.
 
 ## JV-Link Installation Check (Windows)
@@ -316,7 +383,18 @@ MIT License - see [LICENSE](LICENSE) for details.
 ## Contributing
 
 Contributions are welcome. Please:
+
 1. Fork & clone.
 2. Add tests for new record parsers or CLI commands.
 3. Regenerate the error catalog if you modify the spec.
 4. Ensure all tests pass in stub mode.
+
+[badge-ci]: https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml/badge.svg
+[badge-dotnet]: https://img.shields.io/badge/.NET-10.0-512BD4
+[badge-license]: https://img.shields.io/badge/License-MIT-yellow.svg
+[badge-nuget]: https://img.shields.io/nuget/v/Xanthos.svg
+[dotnet-10-downloads]: https://dotnet.microsoft.com/download/dotnet/10.0
+[link-ci]: https://github.com/cariandrum22/Xanthos/actions/workflows/ci.yml
+[link-dotnet]: https://dotnet.microsoft.com/
+[link-license]: https://opensource.org/licenses/MIT
+[link-nuget]: https://www.nuget.org/packages/Xanthos

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -556,8 +556,8 @@ type IJvLinkClient =
     abstract member DeleteFile : filename:string -> Result<unit, ComError>
     abstract member WatchEvent : (string -> unit) -> Result<unit, ComError>
     abstract member WatchEventClose : unit -> Result<unit, ComError>
-    abstract member SavePath : string with get,set
-    abstract member ServiceKey : string with get,set
+    abstract member SavePath : string
+    abstract member ServiceKey : string
     abstract member TotalReadFileSize : int64
     abstract member CurrentFileTimestamp : System.DateTime option
 ```
@@ -575,7 +575,7 @@ The runtime layer lifts `Result<_, ComError>` into `Result<_, XanthosError>` to 
 
 ```fsharp
 // Option 1: Use ComClientFactory with 'use' binding
-// Parameter: useJvGets (None = use env var XANTHOS_USE_JVGETS)
+// Parameter: useJvGets (None = env vars; XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy)
 match ComClientFactory.tryCreate None with
 | Ok client ->
     use client = client  // IJvLinkClient inherits IDisposable

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -91,6 +91,15 @@ tests/
 
 ---
 
+## 3.1 Text Encoding Policy
+
+Xanthos uses a strict boundary-based encoding policy to prevent mojibake and to keep record parsing deterministic.
+
+- **In-memory text**: Unicode `string` (UTF-16). This is the only supported internal text representation.
+- **JV-Link boundary (input)**: treat JV-Link “text” as CP932/Shift-JIS and decode into `string` via `Xanthos.Core.Text` helpers (including COM BSTR recovery for buggy out-params).
+- **Binary payloads**: keep raw `byte[]` as-is; record parsers decode specific field slices from Shift-JIS when (and only when) they are text.
+- **Output boundary (text output)**: console/log/file text is UTF-8 (no BOM). Console apps should call `Xanthos.Runtime.ConsoleEncoding.configureUtf8()` at startup.
+
 ## 4. Layered Architecture
 
 The library consists of three internal layers. Consumers (applications) are external and interact only with the Runtime layer's public API.

--- a/design/architecture/api-coverage.md
+++ b/design/architecture/api-coverage.md
@@ -13,7 +13,7 @@ Status legend: ✅ Implemented / ⚠️ Partial (workaround or property-based) /
 | JVSetSavePath | ✅ | Cache path | `JvLinkService.SetSavePath` (calls `JVSetSavePath`) |
 | JVOpen | ✅ | Batch download | Implemented; returns file count |
 | JVRTOpen | ✅ | Real-time odds | `StreamRealtimePayloads`, `StreamRealtimeAsync` (alias `StreamRealtimePayloadsAsync`) |
-| JVStatus | ✅ | Progress check | Implemented via `IJvLinkClient.Status`; returns download % |
+| JVStatus | ✅ | Progress check | Implemented via `IJvLinkClient.Status`; returns completed file count |
 | JVRead | ✅ | Data retrieval | Implemented with Shift-JIS handling |
 | JVGets | ✅ | Line read | SAFEARRAY byte extraction + Shift-JIS decode; avoids JV-Link internal Unicode conversion |
 | JVSkip | ✅ | Skip file | Implemented via `IJvLinkClient.Skip` |
@@ -83,8 +83,8 @@ This section provides expected return values, error codes, and specification ref
 | m_TotalReadFilesize | ✅ | `JvLinkService.GetTotalReadFileSize` |
 | m_CurrentReadFilesize | ✅ | `JvLinkService.GetCurrentReadFileSize` |
 | m_CurrentFileTimestamp | ✅ | `JvLinkService.GetCurrentFileTimestamp` |
-| ParentHWnd | ✅ | `JvLinkService.SetParentWindowHandle` / `GetParentWindowHandle` (write-only in COM; read fails) |
-| m_payflag | ✅ | `JvLinkService.SetPayoffDialogSuppressed` / `GetPayoffDialogSuppressed` (read-only in COM; write fails) |
+| ParentHWnd | ✅ | `JvLinkService.SetParentWindowHandle` / `GetParentWindowHandle` (write-only in COM; read not supported) |
+| m_payflag | ✅ | `JvLinkService.SetPayoffDialogSuppressed` / `GetPayoffDialogSuppressed` (read-only in COM; write not supported) |
 
 ## Update Guidelines
 

--- a/design/architecture/api-coverage.md
+++ b/design/architecture/api-coverage.md
@@ -70,7 +70,7 @@ This section provides expected return values, error codes, and specification ref
 | JVCourseFile | File path + explanation | -1 (not found) | [methods.md](../specs/methods.md#jvcoursefile) |
 | JVCourseFile2 | File path string | -1 (not found) | [methods.md](../specs/methods.md#jvcoursefile2) |
 
-**Implementation notes**: Implemented in `JvLinkService.GetCourseDiagram` / `GetCourseDiagramBasic`.
+**Implementation notes**: Implemented in `JvLinkService.GetCourseDiagram` / `GetCourseDiagramBasic`. In practice, some JV-Link COM environments return a non-text `explanation` payload for `JVCourseFile`; Xanthos treats this value as best-effort and may suppress obviously garbled strings. For an authoritative course description, prefer parsing `COMM`/`CS` records (course information) via `JVOpen`.
 
 ## Exposed Properties
 

--- a/design/tests/e2e-cli.md
+++ b/design/tests/e2e-cli.md
@@ -16,8 +16,8 @@ This document defines the end-to-end scenarios that the command-line tool must e
 
 | Command | JV-Link APIs | Purpose / Expected Outcome | Stub Coverage |
 | --- | --- | --- | --- |
-| `download --spec <dataspec> --from <ts> [--option <1-4>] [--output <dir>]` | `JVOpen`, repeated `JVRead`, `JVClose` | Materialises all payloads for a dataspec, logs download counts, handles `FileBoundary`/`DownloadPending`. | Yes |
-| `realtime --spec <dataspec> [--from <ts>]` | `JVRTOpen`, repeated `JVRead`, `JVCancel` | Streams realtime payloads until cancelled. | Yes |
+| `download --spec <dataspec> --from <ts> [--option <1-4>] [--output <dir>]` | `JVOpen`, repeated `JVRead`/`JVGets`, `JVClose` | Materialises all payloads for a dataspec, logs download counts, handles `FileBoundary`/`DownloadPending`. | Yes |
+| `realtime --spec <dataspec> --key <key> [--continuous]` | `JVRTOpen`, repeated `JVRead`/`JVGets`, `JVCancel` | Streams realtime payloads (continuous mode polls until cancelled). | Yes |
 | `status` | `JVStatus` | Reports current download status. | Yes |
 | `skip` | `JVSkip` | Skips current file in session. | Yes |
 | `cancel` | `JVCancel` | Cancels current session. | Yes |
@@ -32,13 +32,18 @@ This document defines the end-to-end scenarios that the command-line tool must e
 | `movie-play --key <search>` | `JVMVPlay` | Requests movie playback. | Stub: simulated |
 | `movie-play-with-type --movie-type <code> --key <search>` | `JVMVPlayWithType` | Requests movie playback by type. | Stub: simulated |
 | `movie-open --movie-type <code> --search-key <key>` | `JVMVOpen`, `JVMVRead` | Retrieves all workout video listings in one call via `FetchWorkoutVideos`. | Yes |
-| `version` | `JVLink.Version` | Displays JV-Link version information. | Yes |
+| `version` | `m_JVLinkVersion` | Displays JV-Link version information. | Yes |
 | `set-save-flag --value <bool>` | `JVSetSaveFlag` | Sets save flag. | Yes |
-| `get-save-flag` | `JVGetSaveFlag` | Gets current save flag. | Yes |
+| `get-save-flag` | `m_saveflag` | Gets current save flag. | Yes |
 | `set-save-path --value <path>` | `JVSetSavePath` | Sets save path directory. | Yes |
-| `get-save-path` | `JVGetSavePath` | Gets current save path. | Yes |
+| `get-save-path` | `m_savepath` | Gets current save path. | Yes |
 | `set-service-key --value <key>` | `JVSetServiceKey` | Sets service key. | Yes |
-| `get-service-key` | `JVGetServiceKey` | Gets current service key. | Yes |
+| `get-service-key` | `m_servicekey` | Gets current service key. | Yes |
+| `set-parent-hwnd --value <handle>` | `ParentHWnd` (set) | Sets dialog owner window handle. | Yes |
+| `get-parent-hwnd` | `ParentHWnd` (get) | Gets dialog owner window handle (not supported in COM; `ParentHWnd` is write-only). | Yes (stub only) |
+| `set-payoff-dialog --value <bool>` | `m_payflag` (set) | Suppresses payoff dialogs (not supported in COM; `m_payflag` is read-only). | Yes (stub only) |
+| `get-payoff-dialog` | `m_payflag` (get) | Gets payoff dialog suppression setting. | Yes |
+| `set-ui-properties` | `JVSetUIProperties` | Shows JV-Link configuration dialog and updates registry. | Stub: simulated |
 | `capture-fixtures --output <dir> --specs <list> --from <ts> [--to <ts>] [--max-records <n>] [--use-jvgets]` | `JVOpen`, `JVRead`/`JVGets` | Captures real COM records as test fixtures (Windows only). | No (requires COM) |
 
 ## Execution Flow

--- a/design/tests/e2e-cli.md
+++ b/design/tests/e2e-cli.md
@@ -23,7 +23,7 @@ This document defines the end-to-end scenarios that the command-line tool must e
 | `cancel` | `JVCancel` | Cancels current session. | Yes |
 | `delete-file --name <filename>` | `JVFiledelete` | Deletes an existing file and reports success. | Yes |
 | `watch-events [--duration <sec>] [--open-after]` | `JVWatchEvent`, `JVWatchEventClose` | Subscribes to watch events for specified duration; optionally opens realtime session on event trigger. | Partial (events require stub triggers) |
-| `course-file --key <id>` | `JVCourseFile` | Retrieves course diagram path. | Yes |
+| `course-file --key <id>` | `JVCourseFile` | Retrieves course diagram path (explanation is best-effort and may be omitted if unreadable). | Yes |
 | `course-file2 --key <id>` | `JVCourseFile2` | Retrieves course diagram path (v2). | Yes |
 | `silks-file --pattern <text> --output <path>` | `JVFukuFile` | Generates a bitmap file for the supplied pattern. | Yes |
 | `silks-binary --pattern <text>` | `JVFuku` | Returns silks image bytes (hex encoded). | Yes |

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,12 @@ functional programming style.
 - **Stub mode**: Test without COM dependencies on any platform
 - **Cross-platform**: Core library works on Windows, macOS, and Linux (COM features Windows-only)
 
+## Text Encoding
+
+- **In-memory**: Xanthos represents text as Unicode `string` (UTF-16).
+- **JV-Link input boundary**: JV-Link returns CP932/Shift-JIS for “text”; Xanthos decodes it into `string` via `Xanthos.Core.Text`.
+- **Output boundary**: console/log/file text is UTF-8 (no BOM). `samples/Xanthos.Cli` configures stdout/stderr accordingly.
+
 ## Quick Start
 
 ```fsharp

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {

--- a/samples/Xanthos.Cli/Execution.fs
+++ b/samples/Xanthos.Cli/Execution.fs
@@ -697,18 +697,19 @@ let runCaptureFixtures ctx args =
         printfn "Run this command on Windows with JV-Link installed."
         2
     | Com ->
-        // Set environment variable for JVGets mode only if explicitly requested via CLI option
-        // This preserves any existing environment variable setting when --use-jvgets is not specified
-        if args.UseJvGets then
-            Environment.SetEnvironmentVariable("XANTHOS_USE_JVGETS", "1")
-            printfn "Using JVGets mode (--use-jvgets)"
-        else
-            // Check if environment variable is already set
-            match Environment.GetEnvironmentVariable("XANTHOS_USE_JVGETS") with
-            | "1" -> printfn "Using JVGets mode (from environment variable)"
-            | _ -> ()
+        // Force JVGets when explicitly requested, regardless of env var defaults.
+        let ctxForFixtures =
+            if args.UseJvGets then
+                printfn "Using JVGets mode (--use-jvgets)"
 
-        match tryCreateService ctx with
+                { ctx with
+                    Config =
+                        { ctx.Config with
+                            UseJvGets = Some true } }
+            else
+                ctx
+
+        match tryCreateService ctxForFixtures with
         | Error msg ->
             printfn "ERROR: COM client creation failed: %s" msg
             2

--- a/samples/Xanthos.Cli/Execution.fs
+++ b/samples/Xanthos.Cli/Execution.fs
@@ -527,7 +527,7 @@ let runTotalReadSize ctx =
     withService ctx (fun service ->
         let _ = printEvidence ctx service
 
-        match service.GetTotalReadFileSize() with
+        match service.GetTotalReadFileSizeBytes() with
         | Ok size ->
             printfn "Total read file size: %d bytes" size
             0

--- a/samples/Xanthos.Cli/Execution.fs
+++ b/samples/Xanthos.Cli/Execution.fs
@@ -164,15 +164,42 @@ let runDownload ctx args =
     withService ctx (fun service ->
         let _ = printEvidence ctx service
 
-        match service.FetchPayloads(args.Request) with
+        // When --max-records is set, use StreamPayloads (lazy seq) so that JV-Link
+        // stops reading after N records instead of fetching all 1000+ files first.
+        let fetchResult =
+            match args.MaxRecords with
+            | Some n ->
+                let mutable firstError: XanthosError option = None
+
+                let payloads =
+                    service.StreamPayloads(args.Request)
+                    |> Seq.choose (fun r ->
+                        match r with
+                        | Ok p -> Some p
+                        | Error err ->
+                            if firstError.IsNone then
+                                firstError <- Some err
+
+                            None)
+                    |> Seq.truncate n
+                    |> Seq.toList
+
+                match firstError with
+                | Some err when payloads.IsEmpty -> Error err
+                | _ -> Ok payloads
+            | None -> service.FetchPayloads(args.Request)
+
+        match fetchResult with
         | Ok payloads ->
             payloads
             |> List.iteri (fun idx payload ->
+                let fullText = Text.decodeShiftJis payload.Data
+
                 let preview =
-                    if payload.Data.Length > 50 then
-                        Text.decodeShiftJis payload.Data.[0..49] + "..."
+                    if fullText.Length > 40 then
+                        fullText.[..39] + "..."
                     else
-                        Text.decodeShiftJis payload.Data
+                        fullText
 
                 printfn "Payload %d: %d bytes - %s" (idx + 1) payload.Data.Length preview)
 
@@ -384,13 +411,14 @@ let runCourseFile ctx key =
 
         match service.GetCourseDiagram key with
         | Ok diagram ->
-            let explanation = diagram.Explanation |> Option.defaultValue "(no explanation)"
+            match diagram.Explanation with
+            | Some explanation -> printfn "Course file [%s]: Path=%s Explanation=%s" key diagram.FilePath explanation
+            | None -> printfn "Course file [%s]: Path=%s" key diagram.FilePath
 
-            printfn "Course file [%s]: Path=%s Explanation=%s" key diagram.FilePath explanation
             0
         | Error err -> reportError "Failed to get course file" err)
 
-let runCourseFile2 ctx args =
+let runCourseFile2 ctx (args: CourseFile2Args) =
     withService ctx (fun service ->
         let _ = printEvidence ctx service
 
@@ -754,10 +782,38 @@ let runCaptureFixtures ctx args =
 
                 let request = Validation.createOpenRequest spec args.FromTime 1
 
-                match service.FetchPayloads(request) with
+                // Use StreamPayloads with a total read cap to avoid reading all
+                // records (which can exceed the E2E timeout for large datasets).
+                let totalReadCap = args.MaxRecordsPerType * knownRecordTypes.Length * 3
+                let mutable firstError: XanthosError option = None
+
+                let payloads =
+                    service.StreamPayloads(request)
+                    |> Seq.choose (fun r ->
+                        match r with
+                        | Ok p -> Some p
+                        | Error err ->
+                            if firstError.IsNone then
+                                firstError <- Some err
+
+                            None)
+                    |> Seq.truncate totalReadCap
+                    |> Seq.toList
+
+                let fetchResult =
+                    match firstError with
+                    | Some err when payloads.IsEmpty -> Error err
+                    | _ -> Ok payloads
+
+                match fetchResult with
                 | Ok payloads ->
                     let filteredPayloads = filterByToTime payloads
-                    printfn "  Fetched %d payload(s) (after filter: %d)" payloads.Length filteredPayloads.Length
+
+                    printfn
+                        "  Fetched %d payload(s) (after filter: %d, read cap: %d)"
+                        payloads.Length
+                        filteredPayloads.Length
+                        totalReadCap
 
                     // Group by record type
                     let grouped =
@@ -820,7 +876,7 @@ let runCaptureFixtures ctx args =
                                 let meta =
                                     $"{{\"timestamp\": {timestampJson}, \"byteLength\": {payload.Data.Length}, \"recordType\": \"{recordType}\", \"parseStatus\": \"{parseStatus}\"}}"
 
-                                File.WriteAllText(metaFilename, meta)
+                                File.WriteAllText(metaFilename, meta, ConsoleEncoding.utf8NoBom)
                                 totalCaptured <- totalCaptured + 1)
                     else
                         printfn "  No records to capture for this spec."

--- a/samples/Xanthos.Cli/Parsing.fs
+++ b/samples/Xanthos.Cli/Parsing.fs
@@ -142,7 +142,8 @@ module Parsing =
         { Spec: string option
           From: string option
           OptionText: string option
-          Output: string option }
+          Output: string option
+          MaxRecords: string option }
 
     let rec parseDownloadArgs (state: DownloadRaw) (tokens: string list) : Result<DownloadRaw, string> =
         match tokens with
@@ -155,6 +156,8 @@ module Parsing =
         | "--option" :: v :: rest -> parseDownloadArgs { state with OptionText = Some v } rest
         | "--output" :: [] -> Error "download: option '--output' requires a value."
         | "--output" :: v :: rest -> parseDownloadArgs { state with Output = Some v } rest
+        | "--max-records" :: [] -> Error "download: option '--max-records' requires a value."
+        | "--max-records" :: v :: rest -> parseDownloadArgs { state with MaxRecords = Some v } rest
         | u :: _ -> Error $"download: unknown option '{u}'."
 
     let parseDownload (tokens: string list) : Result<Command, string> =
@@ -164,7 +167,8 @@ module Parsing =
                     { Spec = None
                       From = None
                       OptionText = None
-                      Output = None }
+                      Output = None
+                      MaxRecords = None }
                     tokens
 
             let! rawSpec = raw.Spec |> requireValue "download: --spec is required."
@@ -180,10 +184,18 @@ module Parsing =
             let request = createOpenRequest spec fromTime openOption
             let outputDir = raw.Output |> Option.orElse (readEnv "XANTHOS_JVLINK_OUTPUT")
 
+            let maxRecords =
+                raw.MaxRecords
+                |> Option.bind (fun s ->
+                    match Int32.TryParse s with
+                    | true, v when v > 0 -> Some v
+                    | _ -> None)
+
             return
                 Download
                     { Request = request
-                      OutputDirectory = outputDir }
+                      OutputDirectory = outputDir
+                      MaxRecords = maxRecords }
         }
 
     // Realtime parsing

--- a/samples/Xanthos.Cli/Program.fs
+++ b/samples/Xanthos.Cli/Program.fs
@@ -23,7 +23,7 @@ Global Options:
 Commands:
 
   Data Retrieval:
-    download              Bulk download payloads via JVOpen + JVRead.
+    download              Bulk download payloads via JVOpen + JVRead/JVGets.
       --spec <dataspec>     Data specification (required, e.g., RACE, TOKU).
       --from <timestamp>    Start time YYYYMMDDHHmmss (required).
       --option <1-4>        JVOpen option (default: 1).
@@ -61,8 +61,8 @@ Commands:
     get-service-key       Get current service key.
     set-parent-hwnd       Set parent window handle.
       --value <handle>      Handle value as integer (required).
-    get-parent-hwnd       Get current parent window handle.
-    set-payoff-dialog     Control payoff dialog display.
+    get-parent-hwnd       Get current parent window handle (not supported in COM).
+    set-payoff-dialog     Control payoff dialog display (not supported in COM; use set-ui-properties).
       --value <bool>        Enable/disable (required).
     get-payoff-dialog     Get payoff dialog setting.
     set-ui-properties     Synchronize UI state.

--- a/samples/Xanthos.Cli/Program.fs
+++ b/samples/Xanthos.Cli/Program.fs
@@ -16,6 +16,8 @@ Global Options:
   --save-path <path>      Directory for persisted files (or XANTHOS_JVLINK_SAVE_PATH).
   --stub                  Force stub mode (default on non-Windows).
   --diag                  Enable COM diagnostics output.
+  --use-jvgets            Force JVGets (default) regardless of env vars.
+  --no-jvgets             Force JVRead (equivalent to XANTHOS_USE_JVREAD=1).
   --help                  Show this help text.
 
 Commands:
@@ -106,7 +108,7 @@ Commands:
       --from <timestamp>    Start time YYYYMMDDHHmmss (default: 30 days ago).
       --to <timestamp>      End time YYYYMMDDHHmmss (optional).
       --max-records <n>     Max records per type (default: 10).
-      --use-jvgets          Use JVGets instead of JVRead.
+      --use-jvgets          Force JVGets (default).
 """
 
 let private printHelp () =

--- a/samples/Xanthos.Cli/Program.fs
+++ b/samples/Xanthos.Cli/Program.fs
@@ -28,6 +28,7 @@ Commands:
       --from <timestamp>    Start time YYYYMMDDHHmmss (required).
       --option <1-4>        JVOpen option (default: 1).
       --output <dir>        Output directory for persisted files.
+      --max-records <n>     Max payloads to process (optional, all by default).
 
     realtime              Stream realtime payloads via JVRTOpen.
       --spec <dataspec>     Data specification (required, e.g., 0B12, 0B11).
@@ -109,6 +110,7 @@ Commands:
       --to <timestamp>      End time YYYYMMDDHHmmss (optional).
       --max-records <n>     Max records per type (default: 10).
       --use-jvgets          Force JVGets (default).
+
 """
 
 let private printHelp () =
@@ -154,6 +156,9 @@ let private runCommand ctx command =
 [<STAThread>]
 [<EntryPoint>]
 let main argv =
+    // Ensure all CLI output (stdout/stderr) is UTF-8 to avoid mojibake in logs and test harnesses.
+    Xanthos.Runtime.ConsoleEncoding.configureUtf8 ()
+
     match parseInput argv with
     | Error msg ->
         printfn "%s\n%s" msg (usage.Trim())
@@ -165,8 +170,10 @@ let main argv =
             match createExecutionContext parsed.Globals with
             | Error err -> reportError "Configuration error" err
             | Ok ctx ->
-                printfn "[diag] Client mode = %s" (describeMode ctx.Activation)
                 configureDiagnostics ctx.Globals.EnableDiagnostics ctx.Logger
+
+                if ctx.Globals.EnableDiagnostics then
+                    printfn "[diag] Client mode = %s" (describeMode ctx.Activation)
                 // Each command creates its own service with a fresh client.
                 // The service owns the client and disposes it when done.
                 runCommand ctx parsed.Command

--- a/samples/Xanthos.Cli/Types.fs
+++ b/samples/Xanthos.Cli/Types.fs
@@ -34,7 +34,7 @@ type GlobalSettings =
         StubPreference: StubPreference
         EnableDiagnostics: bool
         /// When Some true, use JVGets (byte array) instead of JVRead (BSTR).
-        /// When None, falls back to XANTHOS_USE_JVGETS environment variable.
+        /// When None, falls back to environment variables (XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy).
         UseJvGets: bool option
     }
 

--- a/samples/Xanthos.Cli/Types.fs
+++ b/samples/Xanthos.Cli/Types.fs
@@ -40,7 +40,8 @@ type GlobalSettings =
 
 type DownloadArgs =
     { Request: JvOpenRequest
-      OutputDirectory: string option }
+      OutputDirectory: string option
+      MaxRecords: int option }
 
 type RealtimeRaw =
     { RealtimeSpec: string option

--- a/src/Xanthos/Core/Text.fs
+++ b/src/Xanthos/Core/Text.fs
@@ -36,6 +36,12 @@ module Text =
             (Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)
              Encoding.GetEncoding("shift_jis", EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback))
 
+    /// <summary>Lenient Shift-JIS (code page 932) encoding used for best-effort recovery.</summary>
+    let private shiftJisEncodingLenient =
+        lazy
+            (Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)
+             Encoding.GetEncoding(932))
+
     /// <summary>Strict UTF-8 encoding for fallback decoding.</summary>
     let private utf8Strict = lazy (new UTF8Encoding(false, true))
 
@@ -89,8 +95,8 @@ module Text =
     /// </returns>
     /// <remarks>
     /// <para>
-    /// This function first attempts Shift-JIS decoding. If that fails (invalid byte sequences),
-    /// it falls back to strict UTF-8, then to lenient UTF-8 as a last resort.
+    /// This function first attempts strict Shift-JIS decoding. If that fails (invalid byte sequences),
+    /// it falls back to lenient Shift-JIS, then strict UTF-8, then lenient UTF-8 as a last resort.
     /// </para>
     /// <para>
     /// Results are cached for performance unless:
@@ -110,10 +116,14 @@ module Text =
                 text.TrimEnd('\u0000')
             with :? DecoderFallbackException ->
                 try
-                    let text = utf8Strict.Value.GetString bytes
+                    let text = shiftJisEncodingLenient.Value.GetString bytes
                     text.TrimEnd('\u0000')
-                with :? DecoderFallbackException ->
-                    Encoding.UTF8.GetString bytes
+                with _ ->
+                    try
+                        let text = utf8Strict.Value.GetString bytes
+                        text.TrimEnd('\u0000')
+                    with :? DecoderFallbackException ->
+                        Encoding.UTF8.GetString bytes
         else
             let key = makeDecodeKey bytes
 
@@ -126,16 +136,381 @@ module Text =
                         text.TrimEnd('\u0000')
                     with :? DecoderFallbackException ->
                         try
-                            let text = utf8Strict.Value.GetString bytes
+                            let text = shiftJisEncodingLenient.Value.GetString bytes
                             text.TrimEnd('\u0000')
-                        with :? DecoderFallbackException ->
-                            Encoding.UTF8.GetString bytes
+                        with _ ->
+                            try
+                                let text = utf8Strict.Value.GetString bytes
+                                text.TrimEnd('\u0000')
+                            with :? DecoderFallbackException ->
+                                Encoding.UTF8.GetString bytes
 
                 if decodeCache.TryAdd(key, decoded) then
                     decodeKeyQueue.Enqueue(key)
                     trimCache decodeKeyQueue decodeCache maxDecodeEntries
 
                 decoded
+
+    /// <summary>
+    /// Decodes JV-Link Shift-JIS bytes that were mistakenly marshalled as a BSTR string.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Some JV-Link COM APIs populate out-parameters using Shift-JIS bytes, but the COM marshaller
+    /// may expose them to .NET as a UTF-16 string without decoding. This function attempts to
+    /// recover the original bytes from common BSTR layouts and decode them as Shift-JIS.
+    /// </para>
+    /// <para>
+    /// If the input already looks like readable Japanese text, it is returned as-is.
+    /// </para>
+    /// </remarks>
+    let decodeShiftJisBstrBytesIfNeeded (text: string) =
+        if String.IsNullOrEmpty text then
+            text
+        else
+            let text =
+                // Common COM out-param patterns:
+                // - Classic fixed buffer: actual content followed by trailing NULs.
+                // - Corruption patterns: embedded NULs (e.g., every other char).
+                // Prefer trimming at the first NUL, unless NULs look strongly interleaved.
+                let firstNul = text.IndexOf('\u0000')
+
+                if firstNul < 0 then
+                    text
+                else
+                    let mutable nulCount = 0
+                    let mutable nulsAtEven = 0
+                    let mutable nulsAtOdd = 0
+
+                    for i = 0 to text.Length - 1 do
+                        if text.[i] = '\u0000' then
+                            nulCount <- nulCount + 1
+
+                            if (i &&& 1) = 0 then
+                                nulsAtEven <- nulsAtEven + 1
+                            else
+                                nulsAtOdd <- nulsAtOdd + 1
+
+                    let dominant = max nulsAtEven nulsAtOdd
+
+                    // Detect the classic "every other char is NUL" pattern that appears when ANSI bytes
+                    // are exposed as UTF-16 code units (e.g., 0x00XX / 0xXX00 layouts).
+                    let looksInterleavedNuls =
+                        nulCount >= 4
+                        && firstNul <= 1
+                        && (nulCount * 2) >= text.Length
+                        && (dominant * 5) >= (nulCount * 4) // >= 80% on one parity
+
+                    if looksInterleavedNuls then
+                        text
+                    else
+                        text.Substring(0, firstNul)
+
+            if String.IsNullOrEmpty text then
+                text
+            else
+                let trimNuls (s: string) = s.TrimEnd('\u0000')
+
+                let removeEmbeddedNuls (s: string) =
+                    if String.IsNullOrEmpty s then
+                        s
+                    else
+                        s.Replace("\u0000", "")
+
+                let tryDecodeShiftJisStrictWithTrimming (bytes: byte[]) =
+                    try
+                        let tryDecode (candidate: byte[]) =
+                            try
+                                let decoded = shiftJisEncoding.Value.GetString candidate
+                                Some(trimNuls decoded)
+                            with :? DecoderFallbackException ->
+                                None
+
+                        if isNull bytes || bytes.Length = 0 then
+                            None
+                        else
+                            match tryDecode bytes with
+                            | Some decoded -> Some decoded
+                            | None ->
+                                // Some JV-Link APIs appear to leave garbage bytes at the end of the buffer.
+                                // Retry by trimming a small number of trailing bytes to recover a valid Shift-JIS sequence.
+                                let maxTrim = min 8 (bytes.Length - 1)
+
+                                [ 1..maxTrim ]
+                                |> List.tryPick (fun trim ->
+                                    let len = bytes.Length - trim
+                                    if len <= 0 then None else tryDecode (Array.take len bytes))
+                    with :? DecoderFallbackException ->
+                        None
+
+                let tryDecodeShiftJisLenient (bytes: byte[]) =
+                    try
+                        if isNull bytes || bytes.Length = 0 then
+                            None
+                        else
+                            let decoded = shiftJisEncodingLenient.Value.GetString bytes
+                            Some(decoded |> trimNuls |> removeEmbeddedNuls)
+                    with _ ->
+                        None
+
+                let bytesFromLowBytePerChar =
+                    text.ToCharArray() |> Array.map (fun ch -> byte (int ch &&& 0xFF))
+
+                let bytesFromHighBytePerChar =
+                    text.ToCharArray() |> Array.map (fun ch -> byte ((int ch >>> 8) &&& 0xFF))
+
+                let bytesFromUtf16LittleEndian =
+                    let bytes = Encoding.Unicode.GetBytes text
+                    bytes |> Array.rev |> Array.skipWhile ((=) 0uy) |> Array.rev
+
+                let bytesFromUtf16BigEndian =
+                    let bytes = Encoding.BigEndianUnicode.GetBytes text
+                    bytes |> Array.rev |> Array.skipWhile ((=) 0uy) |> Array.rev
+
+                let isJapaneseChar (ch: char) =
+                    let code = int ch
+
+                    (code >= 0x3000 && code <= 0x303F) // CJK Symbols and Punctuation
+                    || (code >= 0x3040 && code <= 0x309F) // Hiragana
+                    || (code >= 0x30A0 && code <= 0x30FF) // Katakana
+                    || (code >= 0x4E00 && code <= 0x9FFF) // CJK Unified Ideographs
+
+                let score (s: string) =
+                    let hiraganaCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0x3040 && code <= 0x309F then 1 else 0)
+
+                    let katakanaCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0x30A0 && code <= 0x30FF then 1 else 0)
+
+                    let kanjiCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0x4E00 && code <= 0x9FFF then 1 else 0)
+
+                    let cjkPunctCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0x3000 && code <= 0x303F then 1 else 0)
+
+                    let halfwidthKatakanaCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0xFF61 && code <= 0xFF9F then 1 else 0)
+
+                    let asciiPrintableCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0x20 && code <= 0x7E then 1 else 0)
+
+                    let replacementCount = s |> Seq.sumBy (fun ch -> if ch = '\uFFFD' then 1 else 0)
+                    let nulCount = s |> Seq.sumBy (fun ch -> if ch = '\u0000' then 1 else 0)
+                    let controlCount = s |> Seq.sumBy (fun ch -> if Char.IsControl ch then 1 else 0)
+
+                    let c1ControlCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if code >= 0x80 && code <= 0x9F then 1 else 0)
+
+                    let surrogateCount = s |> Seq.sumBy (fun ch -> if Char.IsSurrogate ch then 1 else 0)
+
+                    let otherNonAsciiPrintableCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            if isJapaneseChar ch then
+                                0
+                            else
+                                let code = int ch
+
+                                if (code >= 0x20 && code <= 0x7E) || Char.IsWhiteSpace ch then
+                                    0
+                                else
+                                    1)
+
+                    // A common corruption pattern is "high-byte stuffed" strings where each UTF-16 code unit is 0xXX00.
+                    // Penalize those to avoid treating random CJK-looking characters as already-decoded Japanese.
+                    let highByteStuffedCount =
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+                            if (code &&& 0xFF) = 0 && (code >>> 8) <> 0 then 1 else 0)
+
+                    (hiraganaCount * 20)
+                    + (katakanaCount * 20)
+                    + (kanjiCount * 10)
+                    + (cjkPunctCount * 5)
+                    + asciiPrintableCount
+                    - (replacementCount * 20)
+                    - (nulCount * 5)
+                    - (controlCount * 5)
+                    - (c1ControlCount * 10)
+                    - (surrogateCount * 10)
+                    - (halfwidthKatakanaCount * 25)
+                    - (otherNonAsciiPrintableCount * 8)
+                    - (highByteStuffedCount * 8)
+
+                let kanaCount =
+                    text
+                    |> Seq.sumBy (fun ch ->
+                        let code = int ch
+
+                        if (code >= 0x3040 && code <= 0x309F) || (code >= 0x30A0 && code <= 0x30FF) then
+                            1
+                        else
+                            0)
+
+                let kanjiCount =
+                    text
+                    |> Seq.sumBy (fun ch ->
+                        let code = int ch
+                        if code >= 0x4E00 && code <= 0x9FFF then 1 else 0)
+
+                let c1ControlCount =
+                    text
+                    |> Seq.sumBy (fun ch ->
+                        let code = int ch
+                        if code >= 0x80 && code <= 0x9F then 1 else 0)
+
+                let highByteStuffedCount =
+                    text
+                    |> Seq.sumBy (fun ch ->
+                        let code = int ch
+                        if (code &&& 0xFF) = 0 && (code >>> 8) <> 0 then 1 else 0)
+
+                let otherNonAsciiPrintableCount =
+                    text
+                    |> Seq.sumBy (fun ch ->
+                        if isJapaneseChar ch then
+                            0
+                        else
+                            let code = int ch
+
+                            if (code >= 0x20 && code <= 0x7E) || Char.IsWhiteSpace ch then
+                                0
+                            else
+                                1)
+
+                let longKanjiOnly = text.Length >= 30 && kanaCount = 0 && kanjiCount > 0
+
+                let decodeFromBytes (bytes: byte[]) =
+                    match tryDecodeShiftJisStrictWithTrimming bytes with
+                    | Some decoded -> Some(removeEmbeddedNuls decoded)
+                    | None -> tryDecodeShiftJisLenient bytes
+
+                let tryDecodeUtf8Strict (bytes: byte[]) =
+                    try
+                        if isNull bytes || bytes.Length = 0 then
+                            None
+                        else
+                            Some(utf8Strict.Value.GetString bytes |> trimNuls |> removeEmbeddedNuls)
+                    with :? DecoderFallbackException ->
+                        None
+
+                let tryDecodeUtf16le (bytes: byte[]) =
+                    try
+                        if isNull bytes || bytes.Length < 2 then
+                            None
+                        else
+                            let bytes =
+                                if bytes.Length % 2 = 0 then
+                                    bytes
+                                else
+                                    bytes |> Array.take (bytes.Length - 1)
+
+                            Some(Encoding.Unicode.GetString bytes |> trimNuls |> removeEmbeddedNuls)
+                    with _ ->
+                        None
+
+                let tryDecodeUtf16be (bytes: byte[]) =
+                    try
+                        if isNull bytes || bytes.Length < 2 then
+                            None
+                        else
+                            let bytes =
+                                if bytes.Length % 2 = 0 then
+                                    bytes
+                                else
+                                    bytes |> Array.take (bytes.Length - 1)
+
+                            Some(Encoding.BigEndianUnicode.GetString bytes |> trimNuls |> removeEmbeddedNuls)
+                    with _ ->
+                        None
+
+                let bytesFromCp932EncodedText =
+                    try
+                        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)
+                        Encoding.GetEncoding(932).GetBytes text
+                    with _ ->
+                        Array.empty
+
+                if c1ControlCount > 0 then
+                    decodeFromBytes bytesFromLowBytePerChar |> Option.defaultValue text
+                elif highByteStuffedCount > 0 then
+                    decodeFromBytes bytesFromHighBytePerChar |> Option.defaultValue text
+                elif otherNonAsciiPrintableCount > 0 || longKanjiOnly then
+                    let decodedCandidates =
+                        [ decodeFromBytes bytesFromUtf16LittleEndian
+                          decodeFromBytes bytesFromUtf16BigEndian
+                          decodeFromBytes bytesFromLowBytePerChar
+                          decodeFromBytes bytesFromHighBytePerChar
+                          // Recover from classic mojibake patterns:
+                          // - UTF-8 bytes decoded as CP932 -> re-encode as CP932, then decode as UTF-8.
+                          // - UTF-16 bytes decoded as CP932 -> re-encode as CP932, then decode as UTF-16.
+                          tryDecodeUtf8Strict bytesFromCp932EncodedText
+                          tryDecodeUtf16le bytesFromCp932EncodedText
+                          tryDecodeUtf16be bytesFromCp932EncodedText ]
+                        |> List.choose id
+
+                    let candidates = text :: decodedCandidates |> List.distinct
+                    let scored = candidates |> List.map (fun s -> s, score s)
+                    let originalScore = score text
+                    let bestText, bestScore = scored |> List.maxBy snd
+
+                    // Require a margin to avoid rewriting already-correct Japanese strings.
+                    if bestText <> text && bestScore > (originalScore + 10) then
+                        bestText
+                    else
+                        text
+                else
+                    text
+
+    /// <summary>
+    /// Heuristically detects obviously garbled (mojibake) text returned by JV-Link.
+    /// </summary>
+    /// <remarks>
+    /// This is intentionally conservative and only flags strings that contain a high amount of
+    /// private-use characters or control characters, which should not appear in normal Japanese
+    /// explanations.
+    /// </remarks>
+    let looksGarbledJvText (text: string) =
+        if String.IsNullOrWhiteSpace text then
+            false
+        else
+            let mutable privateUse = 0
+            let mutable control = 0
+            let mutable replacement = 0
+
+            for ch in text do
+                let code = int ch
+
+                if code >= 0xE000 && code <= 0xF8FF then
+                    privateUse <- privateUse + 1
+                elif ch = '\uFFFD' then
+                    replacement <- replacement + 1
+                elif Char.IsControl ch && ch <> '\r' && ch <> '\n' && ch <> '\t' then
+                    control <- control + 1
+
+            privateUse >= 8 || control >= 16 || replacement >= 16
 
     /// <summary>
     /// Encodes a .NET string to Shift-JIS byte array.

--- a/src/Xanthos/Interop/ComClientFactory.fs
+++ b/src/Xanthos/Interop/ComClientFactory.fs
@@ -49,9 +49,16 @@ module ComClientFactory =
                       Details = ex.Message
                       Exception = Some ex }
 #else
+        let details =
+            if OperatingSystem.IsWindows() then
+                "COM interop is available only in the net10.0-windows build."
+                + " Ensure you reference the Windows target and run in a 32-bit (x86) process."
+            else
+                "Non-Windows platform"
+
         Error
             { Reason = ComFaultReason.ActivationFailure
-              Details = "Non-Windows platform"
+              Details = details
               Exception = None }
 #endif
 

--- a/src/Xanthos/Interop/ComClientFactory.fs
+++ b/src/Xanthos/Interop/ComClientFactory.fs
@@ -8,7 +8,7 @@ module ComClientFactory =
     /// Attempts to create a COM-backed JV-Link client.
     /// </summary>
     /// <param name="useJvGets">Optional flag to use JVGets API instead of JVRead.
-    /// When None, falls back to XANTHOS_USE_JVGETS environment variable.</param>
+    /// When None, falls back to environment variables (XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy).</param>
     /// <returns>
     /// Ok with the client on success, or Error with details on failure.
     /// </returns>

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -281,32 +281,38 @@ type ComJvLinkClient(?useJvGets: bool) =
         | _ -> None
 
     // Determines whether to use JVGets (byte array) instead of JVRead (BSTR).
-    // Priority: 1) constructor parameter, 2) XANTHOS_USE_JVGETS environment variable
-    let checkUseJvGets () =
-        match useJvGetsOverride with
-        | Some value ->
-            Diagnostics.emit $"UseJvGets override={value} (from config)"
-            value
-        | None ->
-            let envValue = Environment.GetEnvironmentVariable("XANTHOS_USE_JVGETS")
-            // Normalize: trim whitespace and convert to lowercase for case-insensitive comparison
-            let normalized =
-                if isNull envValue then
-                    ""
-                else
-                    envValue.Trim().ToLowerInvariant()
+    // Priority: 1) constructor parameter, 2) XANTHOS_USE_JVGETS environment variable.
+    //
+    // The decision is cached because it does not change within a session and emitting this
+    // diagnostic on every record creates excessive log noise.
+    let useJvGetsCached =
+        lazy
+            (match useJvGetsOverride with
+             | Some value ->
+                 Diagnostics.emit $"UseJvGets override={value} (from config)"
+                 value
+             | None ->
+                 let envValue = Environment.GetEnvironmentVariable("XANTHOS_USE_JVGETS")
+                 // Normalize: trim whitespace and convert to lowercase for case-insensitive comparison
+                 let normalized =
+                     if isNull envValue then
+                         ""
+                     else
+                         envValue.Trim().ToLowerInvariant()
 
-            let result =
-                match normalized with
-                | ""
-                | "0"
-                | "false"
-                | "no"
-                | "off" -> false
-                | _ -> true
+                 let result =
+                     match normalized with
+                     | ""
+                     | "0"
+                     | "false"
+                     | "no"
+                     | "off" -> false
+                     | _ -> true
 
-            Diagnostics.emit $"XANTHOS_USE_JVGETS env='{envValue}' -> useJvGets={result}"
-            result
+                 Diagnostics.emit $"XANTHOS_USE_JVGETS env='{envValue}' -> useJvGets={result}"
+                 result)
+
+    let checkUseJvGets () = useJvGetsCached.Value
 
     // JVRead implementation: uses BSTR with UTF-16 byte extraction
     // JVRead returns data as BSTR. JV-Link writes Shift-JIS bytes to the BSTR buffer, but COM
@@ -416,7 +422,6 @@ type ComJvLinkClient(?useJvGets: bool) =
     // Main read dispatcher - selects implementation based on environment variable
     let readRecord () : Result<JvReadOutcome, ComError> =
         if checkUseJvGets () then
-            Diagnostics.emit "Using JVGets path (XANTHOS_USE_JVGETS=1)"
             readRecordViaJvGets ()
         else
             readRecordViaJvRead ()

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -871,9 +871,7 @@ type ComJvLinkClient(?useJvGets: bool) =
 
         member _.SavePath = getPropertyString "m_savepath"
 
-        member _.ServiceKey
-            with get () = getPropertyString "m_servicekey"
-            and set value = setPropertyString "m_servicekey" value |> ignore
+        member _.ServiceKey = getPropertyString "m_servicekey"
 
         member _.TryGetSaveFlag() =
             tryGetPropertyInt "m_saveflag" |> Result.map (fun v -> v <> 0)

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -701,8 +701,13 @@ type ComJvLinkClient(?useJvGets: bool) =
         member _.SetParentWindowHandleDirect handle =
             setPropertyInt "ParentHWnd" (int handle)
 
-        member _.SetPayoffDialogSuppressedDirect suppressed =
-            setPropertyInt "m_payflag" (if suppressed then 1 else 0)
+        member _.SetPayoffDialogSuppressedDirect _suppressed =
+            // NOTE: In COM mode, the m_payflag property is effectively read-only (write fails).
+            // Users can still change this setting via JVSetUIProperties (interactive dialog).
+            Error(
+                InvalidState
+                    "m_payflag cannot be set programmatically in COM mode (property is read-only). Use JVSetUIProperties to change this setting."
+            )
 
         member _.CourseFile key =
             protect "JVCourseFile" (fun () ->
@@ -919,7 +924,10 @@ type ComJvLinkClient(?useJvGets: bool) =
                     | true, dt -> Some dt
                     | false, _ -> None)
 
-        member _.TryGetParentWindowHandle() = tryGetPropertyIntPtr "ParentHWnd"
+        member _.TryGetParentWindowHandle() =
+            // NOTE: ParentHWnd is write-only in COM mode; reading fails.
+            Error(InvalidState "ParentHWnd cannot be read in COM mode (property is write-only).")
+
         member _.TryGetPayoffDialogSuppressed() = tryGetPropertyBool "m_payflag"
 
         member _.JVLinkVersion = getPropertyString "m_JVLinkVersion"
@@ -944,12 +952,18 @@ type ComJvLinkClient(?useJvGets: bool) =
                 | false, _ -> None
 
         member _.ParentWindowHandle
-            with get () = IntPtr(getPropertyInt "ParentHWnd")
+            with get () =
+                // NOTE: ParentHWnd is write-only in COM mode; return a safe default.
+                IntPtr.Zero
             and set value = setPropertyInt "ParentHWnd" (int value) |> ignore
 
         member _.PayoffDialogSuppressed
             with get () = getPropertyInt "m_payflag" <> 0
-            and set value = setPropertyInt "m_payflag" (if value then 1 else 0) |> ignore
+            and set _ =
+                // NOTE: In COM mode, the m_payflag property is effectively read-only (write fails).
+                // Keep the setter as a no-op to avoid spurious COM errors when consumers use property syntax.
+                Diagnostics.emit "WARN m_payflag is read-only in COM mode; ignoring PayoffDialogSuppressed set."
+                ()
 
     /// <summary>
     /// Releases COM resources and disconnects event subscriptions.

--- a/src/Xanthos/Interop/ComJvLinkClient.fs
+++ b/src/Xanthos/Interop/ComJvLinkClient.fs
@@ -712,23 +712,178 @@ type ComJvLinkClient(?useJvGets: bool) =
         member _.CourseFile key =
             protect "JVCourseFile" (fun () ->
                 // JVCourseFile: key (in), filepath (out ByRef), explanation (out ByRef)
-                let args: obj[] = [| key; ""; "" |]
-                let code = invokeWithByRef "JVCourseFile" args [ 1; 2 ]
+                //
+                // JV-Link COM implementations vary:
+                // - Some allocate fresh BSTRs for out-parameters (standard COM behavior).
+                // - Others appear to write into the provided BSTR buffer (non-standard but observed in the wild).
+                //
+                // Default to the buffered strategy (safer for long strings), but fall back to the allocate strategy
+                // when the decoded explanation looks like obvious mojibake/garbage.
 
-                match ensureSuccess "JVCourseFile" code with
-                | Ok() ->
-                    let filepath =
-                        match args.[1] with
-                        | :? string as s -> s
-                        | _ -> ""
+                let outStringBuffer (size: int) =
+                    if size <= 0 then "" else String(char 0, size)
 
-                    let explanation =
-                        match args.[2] with
-                        | :? string as s -> s
-                        | _ -> ""
+                let isPrivateUseChar (ch: char) =
+                    let code = int ch
+                    code >= 0xE000 && code <= 0xF8FF
 
-                    Ok(filepath, explanation)
-                | Error e -> Error e)
+                let japaneseCount (s: string) =
+                    if String.IsNullOrEmpty s then
+                        0
+                    else
+                        s
+                        |> Seq.sumBy (fun ch ->
+                            let code = int ch
+
+                            if
+                                (code >= 0x3040 && code <= 0x309F) // Hiragana
+                                || (code >= 0x30A0 && code <= 0x30FF) // Katakana
+                                || (code >= 0x4E00 && code <= 0x9FFF)
+                            then // Kanji
+                                1
+                            else
+                                0)
+
+                let garbledScore (s: string) =
+                    if String.IsNullOrWhiteSpace s then
+                        Int32.MinValue
+                    else
+                        let mutable privateUse = 0
+                        let mutable control = 0
+                        let mutable replacement = 0
+                        let mutable ascii = 0
+
+                        for ch in s do
+                            if ch = '\uFFFD' then
+                                replacement <- replacement + 1
+                            elif isPrivateUseChar ch then
+                                privateUse <- privateUse + 1
+                            elif Char.IsControl ch && ch <> '\r' && ch <> '\n' && ch <> '\t' then
+                                control <- control + 1
+                            else
+                                let code = int ch
+
+                                if code >= 0x20 && code <= 0x7E then
+                                    ascii <- ascii + 1
+
+                        // Higher is better
+                        (japaneseCount s * 10) + ascii
+                        - (privateUse * 40)
+                        - (replacement * 50)
+                        - (control * 20)
+
+                let emitTextSummary (label: string) (text: string) =
+                    let safe = if isNull text then "" else text
+                    let maxHead = min 32 safe.Length
+                    let mutable privateUse = 0
+                    let mutable control = 0
+                    let mutable replacement = 0
+
+                    for ch in safe do
+                        if ch = '\uFFFD' then
+                            replacement <- replacement + 1
+                        elif isPrivateUseChar ch then
+                            privateUse <- privateUse + 1
+                        elif Char.IsControl ch && ch <> '\r' && ch <> '\n' && ch <> '\t' then
+                            control <- control + 1
+
+                    let headU16 =
+                        [ 0 .. maxHead - 1 ]
+                        |> List.map (fun i -> (int safe.[i]).ToString("X4"))
+                        |> String.concat " "
+
+                    Diagnostics.emit
+                        $"JVCourseFile {label}: len={safe.Length} jp={japaneseCount safe} privateUse={privateUse} control={control} repl={replacement} score={garbledScore safe} headU16={headU16}"
+
+                let callBuffered () =
+                    let args: obj[] =
+                        [| key
+                           outStringBuffer 512 // filepath
+                           outStringBuffer 16384 |] // explanation (can be long)
+
+                    let code = invokeWithByRef "JVCourseFile" args [ 1; 2 ]
+
+                    match ensureSuccess "JVCourseFile" code with
+                    | Ok() ->
+                        let filepath =
+                            match args.[1] with
+                            | :? string as s -> s
+                            | _ -> ""
+
+                        let explanation =
+                            match args.[2] with
+                            | :? string as s -> s
+                            | _ -> ""
+
+                        Ok(
+                            Text.decodeShiftJisBstrBytesIfNeeded filepath,
+                            Text.decodeShiftJisBstrBytesIfNeeded explanation
+                        )
+                    | Error e -> Error e
+
+                let callAllocate () =
+                    // Use empty placeholders for ByRef string out-parameters and let COM allocate BSTRs.
+                    let args: obj[] = [| key; ""; "" |]
+                    let code = invokeWithByRef "JVCourseFile" args [ 1; 2 ]
+
+                    match ensureSuccess "JVCourseFile" code with
+                    | Ok() ->
+                        let filepath =
+                            match args.[1] with
+                            | :? string as s -> s
+                            | _ -> ""
+
+                        let explanation =
+                            match args.[2] with
+                            | :? string as s -> s
+                            | _ -> ""
+
+                        Ok(
+                            Text.decodeShiftJisBstrBytesIfNeeded filepath,
+                            Text.decodeShiftJisBstrBytesIfNeeded explanation
+                        )
+                    | Error e -> Error e
+
+                let mode =
+                    match Environment.GetEnvironmentVariable("XANTHOS_COM_COURSEFILE_OUT_MODE") with
+                    | null
+                    | "" -> "auto"
+                    | v -> v.Trim().ToLowerInvariant()
+
+                match mode with
+                | "allocate" -> callAllocate ()
+                | "buffer"
+                | "buffered" -> callBuffered ()
+                | _ ->
+                    match callBuffered () with
+                    | Ok(p1, e1) as ok1 ->
+                        if Text.looksGarbledJvText e1 then
+                            Diagnostics.emit
+                                $"JVCourseFile explanation looks garbled (buffered). Retrying with allocate mode. score={garbledScore e1}"
+
+                            match callAllocate () with
+                            | Ok(p2, e2) as ok2 ->
+                                let s1 = garbledScore e1
+                                let s2 = garbledScore e2
+
+                                emitTextSummary "buffered/explanation" e1
+                                emitTextSummary "allocate/explanation" e2
+
+                                if s2 > s1 then
+                                    Diagnostics.emit $"JVCourseFile chose allocate mode (score {s2} > {s1})."
+                                    ok2
+                                else
+                                    Diagnostics.emit $"JVCourseFile kept buffered mode (score {s1} >= {s2})."
+                                    ok1
+                            | Error _ -> ok1
+                        else
+                            ok1
+                    | Error e1 ->
+                        Diagnostics.emit $"JVCourseFile buffered call failed: {e1}. Retrying with allocate mode."
+
+                        match callAllocate () with
+                        | Ok _ as ok -> ok
+                        | Error _ -> Error e1)
 
         member _.CourseFile2(key, filepath) =
             protect "JVCourseFile2" (fun () ->

--- a/src/Xanthos/Interop/IJvLinkClient.fs
+++ b/src/Xanthos/Interop/IJvLinkClient.fs
@@ -137,9 +137,13 @@ type IJvLinkClient =
     /// The getter returns an empty string if COM property access fails. Use <see cref="TryGetSavePath"/> for explicit error handling.
     /// </remarks>
     abstract member SavePath: string
-    /// <summary>Gets or sets the service key configured within JV-Link.</summary>
-    /// <remarks>The getter returns an empty string if COM property access fails. Use <see cref="TryGetServiceKey"/> for explicit error handling.</remarks>
-    abstract member ServiceKey: string with get, set
+    /// <summary>Gets the service key configured within JV-Link.</summary>
+    /// <remarks>
+    /// This property is read-only. Per JV-Link specification, m_servicekey can only be modified
+    /// via JVSetServiceKey or JVSetUIProperties methods.
+    /// The getter returns an empty string if COM property access fails. Use <see cref="TryGetServiceKey"/> for explicit error handling.
+    /// </remarks>
+    abstract member ServiceKey: string
     /// <summary>Attempts to retrieve whether downloads are persisted to disk (<c>m_saveflag</c>).</summary>
     /// <returns>Ok(bool) on success, or Error if COM property access fails.</returns>
     abstract member TryGetSaveFlag: unit -> Result<bool, ComError>

--- a/src/Xanthos/Interop/IJvLinkClient.fs
+++ b/src/Xanthos/Interop/IJvLinkClient.fs
@@ -101,9 +101,16 @@ type IJvLinkClient =
     abstract member SetServiceKeyDirect: key: string -> Result<unit, ComError>
     /// <summary>Sets the save path via `JVSetSavePath`.</summary>
     abstract member SetSavePathDirect: path: string -> Result<unit, ComError>
-    /// <summary>Sets the parent window handle via property assignment.</summary>
+    /// <summary>Sets the parent window handle for JV-Link dialogs (<c>ParentHWnd</c>).</summary>
+    /// <remarks>
+    /// In COM mode, <c>ParentHWnd</c> is write-only: reading it back is not supported.
+    /// </remarks>
     abstract member SetParentWindowHandleDirect: handle: IntPtr -> Result<unit, ComError>
-    /// <summary>Sets whether payoff dialogs are suppressed via property assignment.</summary>
+    /// <summary>Attempts to set whether payoff dialogs are suppressed (<c>m_payflag</c>).</summary>
+    /// <remarks>
+    /// In COM mode, <c>m_payflag</c> is effectively read-only (write fails). Users can still change this
+    /// setting interactively via <see cref="SetUiProperties"/> (JVSetUIProperties dialog).
+    /// </remarks>
     abstract member SetPayoffDialogSuppressedDirect: suppressed: bool -> Result<unit, ComError>
     /// <summary>Retrieves a course diagram with explanation.</summary>
     abstract member CourseFile: key: string -> Result<string * string, ComError>
@@ -167,7 +174,8 @@ type IJvLinkClient =
     /// <returns>Ok(DateTime option) on success, or Error if COM property access fails.</returns>
     abstract member TryGetCurrentFileTimestamp: unit -> Result<DateTime option, ComError>
     /// <summary>Attempts to retrieve the parent window handle for JV dialogs.</summary>
-    /// <returns>Ok(IntPtr) on success, or Error if COM property access fails.</returns>
+    /// <remarks>In COM mode, <c>ParentHWnd</c> is write-only and cannot be read.</remarks>
+    /// <returns>Ok(IntPtr) on success, or Error if the value cannot be read.</returns>
     abstract member TryGetParentWindowHandle: unit -> Result<IntPtr, ComError>
     /// <summary>Attempts to retrieve whether payoff dialogs are suppressed (<c>m_payflag</c>).</summary>
     /// <returns>Ok(bool) on success, or Error if COM property access fails.</returns>
@@ -185,8 +193,15 @@ type IJvLinkClient =
     /// <remarks>The getter returns None if COM property access fails. Use <see cref="TryGetCurrentFileTimestamp"/> for explicit error handling.</remarks>
     abstract member CurrentFileTimestamp: DateTime option
     /// <summary>Gets or sets the parent window handle for JV dialogs.</summary>
-    /// <remarks>The getter returns IntPtr.Zero if COM property access fails. Use <see cref="TryGetParentWindowHandle"/> for explicit error handling.</remarks>
+    /// <remarks>
+    /// In COM mode, <c>ParentHWnd</c> is write-only. The getter returns IntPtr.Zero.
+    /// Use <see cref="TryGetParentWindowHandle"/> for explicit error handling.
+    /// </remarks>
     abstract member ParentWindowHandle: IntPtr with get, set
     /// <summary>Gets or sets whether payoff dialogs are suppressed (<c>m_payflag</c>).</summary>
-    /// <remarks>The getter returns false if COM property access fails. Use <see cref="TryGetPayoffDialogSuppressed"/> for explicit error handling.</remarks>
+    /// <remarks>
+    /// In COM mode, <c>m_payflag</c> is effectively read-only: setting it programmatically is not supported.
+    /// The setter is best-effort and may be ignored. Use <see cref="SetUiProperties"/> to change the value interactively.
+    /// The getter returns false if COM property access fails. Use <see cref="TryGetPayoffDialogSuppressed"/> for explicit error handling.
+    /// </remarks>
     abstract member PayoffDialogSuppressed: bool with get, set

--- a/src/Xanthos/Interop/JvLinkStub.fs
+++ b/src/Xanthos/Interop/JvLinkStub.fs
@@ -236,6 +236,7 @@ type JvLinkStub(responses: seq<Result<JvReadOutcome, ComError>>, ?totalSize: int
 
         /// <inheritdoc />
         member _.SetServiceKeyDirect key =
+            serviceKey <- key
             lastServiceKey <- Some key
             Ok()
 
@@ -304,9 +305,7 @@ type JvLinkStub(responses: seq<Result<JvReadOutcome, ComError>>, ?totalSize: int
         member _.SavePath = savePath
 
         /// <inheritdoc />
-        member _.ServiceKey
-            with get () = serviceKey
-            and set value = serviceKey <- value
+        member _.ServiceKey = serviceKey
 
         /// <inheritdoc />
         member _.TryGetSaveFlag() = Ok saveFlag

--- a/src/Xanthos/Runtime/Configuration.fs
+++ b/src/Xanthos/Runtime/Configuration.fs
@@ -37,7 +37,7 @@ type JvLinkConfig =
         SavePath: string option
         ServiceKey: string option
         /// When Some true, use JVGets (byte array) instead of JVRead (BSTR).
-        /// When None, falls back to XANTHOS_USE_JVGETS environment variable.
+        /// When None, falls back to environment variables (XANTHOS_USE_JVREAD opt-out, XANTHOS_USE_JVGETS legacy).
         UseJvGets: bool option
     }
 

--- a/src/Xanthos/Runtime/ConsoleEncoding.fs
+++ b/src/Xanthos/Runtime/ConsoleEncoding.fs
@@ -1,0 +1,46 @@
+namespace Xanthos.Runtime
+
+open System
+open System.IO
+open System.Text
+
+/// UTF-8 helpers for console apps and test harnesses.
+///
+/// Xanthos treats all in-memory text as Unicode strings (UTF-16). JV-Link boundaries
+/// decode CP932/Shift-JIS into those strings, and output boundaries should emit UTF-8.
+module ConsoleEncoding =
+
+    /// UTF-8 without BOM (preferred for logs / redirected output).
+    let utf8NoBom = UTF8Encoding(false)
+
+    /// Best-effort: configure stdout/stderr/input to use UTF-8.
+    ///
+    /// - Works for redirected output (pipes) and most modern Windows consoles.
+    /// - Errors are swallowed to avoid crashing when no console is attached.
+    let configureUtf8 () =
+        // Stdout
+        try
+            let writer = new StreamWriter(Console.OpenStandardOutput(), utf8NoBom)
+            writer.AutoFlush <- true
+            Console.SetOut(writer)
+        with _ ->
+            ()
+
+        // Stderr
+        try
+            let writer = new StreamWriter(Console.OpenStandardError(), utf8NoBom)
+            writer.AutoFlush <- true
+            Console.SetError(writer)
+        with _ ->
+            ()
+
+        // Console encodings (may throw in some hosts)
+        try
+            Console.OutputEncoding <- utf8NoBom
+        with _ ->
+            ()
+
+        try
+            Console.InputEncoding <- utf8NoBom
+        with _ ->
+            ()

--- a/src/Xanthos/Runtime/JvLinkService.fs
+++ b/src/Xanthos/Runtime/JvLinkService.fs
@@ -358,16 +358,7 @@ type JvLinkService
                     let result =
                         executeCom defaultRetryPolicy "SetServiceKeyDirect" (fun () -> client.SetServiceKeyDirect key)
 
-                    match result |> Errors.mapComError with
-                    | Error e -> Error e
-                    | Ok() ->
-                        // Also update the cached property for consistency
-                        try
-                            client.ServiceKey <- key
-                        with _ ->
-                            ()
-
-                        Ok()
+                    result |> Errors.mapComError
                 | None -> Ok()
 
     let openSessionFor request =
@@ -1464,10 +1455,6 @@ type JvLinkService
         guardedWithInitialisation "SetServiceKey" (fun () ->
             match runCom "JVSetServiceKey" (fun () -> client.SetServiceKeyDirect trimmed) with
             | Ok() ->
-                try
-                    client.ServiceKey <- trimmed
-                with _ ->
-                    ()
                 // Update currentConfig so next initialization uses the new value
                 currentConfig <-
                     { currentConfig with

--- a/src/Xanthos/Runtime/JvLinkService.fs
+++ b/src/Xanthos/Runtime/JvLinkService.fs
@@ -1556,7 +1556,7 @@ type JvLinkService
             |> Result.map (fun (path, explanation) ->
                 { FilePath = path
                   Explanation =
-                    if String.IsNullOrWhiteSpace explanation then
+                    if String.IsNullOrWhiteSpace explanation || Text.looksGarbledJvText explanation then
                         None
                     else
                         Some explanation }))

--- a/src/Xanthos/Xanthos.fsproj
+++ b/src/Xanthos/Xanthos.fsproj
@@ -9,7 +9,7 @@
     <PackageId>Xanthos</PackageId>
     <AssemblyName>Xanthos</AssemblyName>
     <RootNamespace>Xanthos</RootNamespace>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>cariandrum22</Authors>
     <Description>F# wrapper library for the JRA-VAN JV-Link COM API. Provides type-safe access to Japanese horse racing data.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Xanthos/Xanthos.fsproj
+++ b/src/Xanthos/Xanthos.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="Interop\ComJvLinkClient.fs" />
     <Compile Include="Interop\ComClientFactory.fs" />
     <Compile Include="Runtime\Configuration.fs" />
+    <Compile Include="Runtime\ConsoleEncoding.fs" />
     <Compile Include="Runtime\DownloadMonitor.fs" />
     <Compile Include="Runtime\Instrumentation.fs" />
     <Compile Include="Runtime\RetryPolicy.fs" />

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF,0B12" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 10
 ```
 
@@ -32,7 +32,7 @@ dotnet run --project samples/Xanthos.Cli -- \
 |--------|-------------|
 | `--output` | Directory to save fixtures (required) |
 | `--specs` | Comma-separated list of data specs (required) |
-| `--from` | Start date for data retrieval (required) |
+| `--from` | Start time for data retrieval (`yyyyMMdd` or `yyyyMMddHHmmss`; required) |
 | `--max-records` | Max records per record type (default: 10) |
 
 ### Fixture Directory Structure
@@ -108,7 +108,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     --sid YOUR_SID capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 10
 ```
 
@@ -118,7 +118,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     --sid YOUR_SID capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF,0B12,0B31,BLOD" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 5
 ```
 
@@ -128,7 +128,7 @@ dotnet run --project samples/Xanthos.Cli -- \
     --sid YOUR_SID capture-fixtures \
     --output tests/fixtures \
     --specs "RACE,DIFF,0B12,0B31,BLOD,SNAP,YSCH" \
-    --from "2024-01-01" \
+    --from "20240101" \
     --max-records 3
 ```
 
@@ -233,7 +233,8 @@ Run the E2E test suite in COM mode on Windows:
 ```powershell
 # Set environment for COM mode
 $env:XANTHOS_E2E_MODE = "COM"
-$env:XANTHOS_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SERVICE_KEY = "YOUR_SERVICE_KEY"
 
 # Run E2E tests
 dotnet test tests/Xanthos.Cli.E2E --filter "Category=E2E"
@@ -248,9 +249,9 @@ Expected: All tests pass or skip appropriately based on COM availability.
 3. Configure launch settings with your SID:
    ```json
    {
-     "profiles": {
-       "Xanthos.Cli": {
-         "commandLineArgs": "--sid YOUR_SID fetch --spec RACE --from 20240101",
+       "profiles": {
+         "Xanthos.Cli": {
+         "commandLineArgs": "--sid YOUR_SID download --spec RACE --from 20240101",
          "environmentVariables": {
            "XANTHOS_USE_JVREAD": "1"
          }
@@ -279,7 +280,7 @@ Test the JVRead API path (opt-out):
 
 ```powershell
 $env:XANTHOS_USE_JVREAD = "1"
-dotnet run --project samples/Xanthos.Cli -- --sid YOUR_SID fetch --spec RACE --from 20240101
+dotnet run --project samples/Xanthos.Cli -- --sid YOUR_SID download --spec RACE --from 20240101
 ```
 
 Expected: Data fetched using JVRead instead of JVGets.
@@ -380,18 +381,19 @@ Before tagging a release, the following COM smoke tests **MUST** pass on a Windo
 ```powershell
 # Set environment for COM mode
 $env:XANTHOS_E2E_MODE = "COM"
-$env:XANTHOS_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SID = "YOUR_SID"
+$env:XANTHOS_E2E_SERVICE_KEY = "YOUR_SERVICE_KEY"
 
 # 1. Verify COM instantiation works
-dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID version
+dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_E2E_SID version
 
 # 2. Verify data fetching (JVRead path / opt-out)
 $env:XANTHOS_USE_JVREAD = "1"
-dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
+dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_E2E_SID --service-key $env:XANTHOS_E2E_SERVICE_KEY download --spec RACE --from 20240101
 
 # 3. Verify JVGets path (default / opt-in)
 $env:XANTHOS_USE_JVREAD = "0"
-dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
+dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_E2E_SID --service-key $env:XANTHOS_E2E_SERVICE_KEY download --spec RACE --from 20240101
 
 # 4. Run E2E test suite in COM mode
 dotnet test tests/Xanthos.Cli.E2E --filter "Category=E2E"
@@ -411,8 +413,8 @@ Before each release, fill out and include in the release notes:
 
 **Smoke Test Results:**
 - [ ] `version` command: COM client instantiated successfully
-- [ ] `fetch` command (JVRead): Data retrieved and parsed
-- [ ] `fetch` command (JVGets): Data retrieved via JVGets (default)
+- [ ] `download` command (JVRead): Data retrieved and parsed
+- [ ] `download` command (JVGets): Data retrieved via JVGets (default)
 - [ ] E2E test suite (COM mode): All tests pass
 
 **Verified By:** ____________

--- a/tests/README.md
+++ b/tests/README.md
@@ -252,7 +252,7 @@ Expected: All tests pass or skip appropriately based on COM availability.
        "Xanthos.Cli": {
          "commandLineArgs": "--sid YOUR_SID fetch --spec RACE --from 20240101",
          "environmentVariables": {
-           "XANTHOS_USE_JVGETS": "0"
+           "XANTHOS_USE_JVREAD": "1"
          }
        }
      }
@@ -273,16 +273,16 @@ Get-ChildItem -Recurse ./fixtures/*.bin | Measure-Object
 
 Expected: `.bin` and `.meta.json` files created for each record type.
 
-### 4. JVGets Mode Verification
+### 4. JVRead Mode Verification
 
-Test the JVGets API path:
+Test the JVRead API path (opt-out):
 
 ```powershell
-$env:XANTHOS_USE_JVGETS = "1"
+$env:XANTHOS_USE_JVREAD = "1"
 dotnet run --project samples/Xanthos.Cli -- --sid YOUR_SID fetch --spec RACE --from 20240101
 ```
 
-Expected: Data fetched using JVGets instead of JVOpen.
+Expected: Data fetched using JVRead instead of JVGets.
 
 ## Verification Checklist
 
@@ -300,7 +300,8 @@ Use this checklist before releases:
 - [ ] CLI E2E (COM mode) - All pass
 - [ ] Visual Studio debug run - Success
 - [ ] Fixture capture - Files generated
-- [ ] JVGets mode - Data fetched
+- [ ] JVGets mode (default) - Data fetched
+- [ ] JVRead mode (XANTHOS_USE_JVREAD=1) - Data fetched
 
 **Record Types Verified:**
 - [ ] TK (Track info)
@@ -384,11 +385,12 @@ $env:XANTHOS_SID = "YOUR_SID"
 # 1. Verify COM instantiation works
 dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID version
 
-# 2. Verify data fetching (JVRead path)
+# 2. Verify data fetching (JVRead path / opt-out)
+$env:XANTHOS_USE_JVREAD = "1"
 dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
 
-# 3. Verify JVGets path (if using Gets mode)
-$env:XANTHOS_USE_JVGETS = "1"
+# 3. Verify JVGets path (default / opt-in)
+$env:XANTHOS_USE_JVREAD = "0"
 dotnet run --project samples/Xanthos.Cli -- --sid $env:XANTHOS_SID fetch --spec RACE --from 20240101 --limit 5
 
 # 4. Run E2E test suite in COM mode
@@ -410,7 +412,7 @@ Before each release, fill out and include in the release notes:
 **Smoke Test Results:**
 - [ ] `version` command: COM client instantiated successfully
 - [ ] `fetch` command (JVRead): Data retrieved and parsed
-- [ ] `fetch` command (JVGets): Data retrieved via Gets API (if applicable)
+- [ ] `fetch` command (JVGets): Data retrieved via JVGets (default)
 - [ ] E2E test suite (COM mode): All tests pass
 
 **Verified By:** ____________

--- a/tests/Xanthos.Cli.E2E/CliTests.fs
+++ b/tests/Xanthos.Cli.E2E/CliTests.fs
@@ -723,6 +723,8 @@ type CliTests(output: ITestOutputHelper, fixture: ServiceKeySetupFixture) =
     [<Trait("Category", "Silks")>]
     member _.``silks-file generates silks bitmap``() =
         let outputPath = Path.Combine(Harness.savePath, "silks-test", "output.bmp")
+        // JV-Link requires the output directory to exist.
+        Directory.CreateDirectory(Path.GetDirectoryName outputPath) |> ignore
 
         let result =
             Harness.runCli mode [ "silks-file"; "--pattern"; silksTestPattern; "--output"; outputPath ]

--- a/tests/Xanthos.Cli.E2E/CliTests.fs
+++ b/tests/Xanthos.Cli.E2E/CliTests.fs
@@ -3,6 +3,7 @@ namespace Xanthos.Cli.E2E
 open System
 open System.Diagnostics
 open System.IO
+open System.Text
 open Xunit
 open Xunit.Abstractions
 
@@ -19,6 +20,52 @@ type CliResult =
       LogFile: string }
 
 module Harness =
+    type private OutputEncodingMode =
+        | Utf8
+        | Cp932
+
+    let private outputEncodingMode =
+        match Environment.GetEnvironmentVariable "XANTHOS_E2E_OUTPUT_ENCODING" with
+        // CLI output is expected to be UTF-8 (see Xanthos.Runtime.ConsoleEncoding).
+        // Keep CP932 only as an explicit escape hatch for debugging legacy behaviour.
+        | v when not (isNull v) && v.Equals("cp932", StringComparison.OrdinalIgnoreCase) -> Cp932
+        | _ -> Utf8
+
+    let private utf8NoBom = UTF8Encoding(false)
+    let private utf8Strict = UTF8Encoding(false, true)
+
+    let private decodeProcessOutput (bytes: byte[]) =
+        if isNull bytes || bytes.Length = 0 then
+            ""
+        else
+            let decodeUtf8Strict (data: byte[]) = utf8Strict.GetString data
+
+            let decodeUtf8Lenient (data: byte[]) = Encoding.UTF8.GetString data
+
+            let decodeCp932 (data: byte[]) =
+                try
+                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)
+                    Encoding.GetEncoding(932).GetString data
+                with _ ->
+                    ""
+
+            match outputEncodingMode with
+            | Cp932 -> decodeCp932 bytes
+            | Utf8 ->
+                // The CLI forces UTF-8 output. If decoding fails, treat it as a test failure signal
+                // by preserving bytes via lenient UTF-8 (replacement chars) rather than silently
+                // interpreting as CP932.
+                try
+                    decodeUtf8Strict bytes
+                with :? DecoderFallbackException ->
+                    decodeUtf8Lenient bytes
+
+    let private readAllBytesAsync (stream: Stream) =
+        System.Threading.Tasks.Task.Run(fun () ->
+            use ms = new MemoryStream()
+            stream.CopyTo(ms)
+            ms.ToArray())
+
     let rec private findRepoRoot startDir dir =
         if File.Exists(Path.Combine(dir, "Xanthos.sln")) then
             dir
@@ -124,7 +171,8 @@ module Harness =
                 + stdout
                 + "\n---\nSTDERR:\n"
                 + stderr
-                + "\n"
+                + "\n",
+                utf8NoBom
             )
 
             Some file
@@ -349,7 +397,7 @@ module Harness =
                   $"fallbackReason={fallbackReasonValue}"
                   $"appBaseDir={AppContext.BaseDirectory}" ]
 
-            File.WriteAllLines(harnessInitLogFile, lines)
+            File.WriteAllLines(harnessInitLogFile, lines, utf8NoBom)
         with _ ->
             ()
 
@@ -453,7 +501,7 @@ module Harness =
         Directory.CreateDirectory logsDir |> ignore
         let name = commandArgs |> String.concat "_" |> sanitizeFileName
         let file = Path.Combine(logsDir, name + ".log")
-        File.WriteAllText(file, "STDOUT:\n" + stdout + "\n---\nSTDERR:\n" + stderr)
+        File.WriteAllText(file, "STDOUT:\n" + stdout + "\n---\nSTDERR:\n" + stderr, utf8NoBom)
         file
 
     let private createProcessStartInfo mode commandArgs =
@@ -532,8 +580,8 @@ module Harness =
                 | true, ms when ms > 0 -> ms
                 | _ -> 60000
 
-        let out = proc.StandardOutput.ReadToEnd()
-        let err = proc.StandardError.ReadToEnd()
+        let stdoutTask = readAllBytesAsync proc.StandardOutput.BaseStream
+        let stderrTask = readAllBytesAsync proc.StandardError.BaseStream
         let exited = proc.WaitForExit(timeoutMs)
 
         if not exited then
@@ -541,6 +589,11 @@ module Harness =
                 proc.Kill(true)
             with _ ->
                 ()
+
+        let outBytes = stdoutTask.GetAwaiter().GetResult()
+        let errBytes = stderrTask.GetAwaiter().GetResult()
+        let out = decodeProcessOutput outBytes
+        let err = decodeProcessOutput errBytes
 
         let exitCode = if exited then proc.ExitCode else -1
         let logFile = writeLog commandArgs out err
@@ -568,8 +621,8 @@ module Harness =
                 | true, ms when ms > 0 -> ms
                 | _ -> 60000
 
-        let out = proc.StandardOutput.ReadToEnd()
-        let err = proc.StandardError.ReadToEnd()
+        let stdoutTask = readAllBytesAsync proc.StandardOutput.BaseStream
+        let stderrTask = readAllBytesAsync proc.StandardError.BaseStream
         let exited = proc.WaitForExit(timeoutMs)
 
         if not exited then
@@ -577,6 +630,11 @@ module Harness =
                 proc.Kill(true)
             with _ ->
                 ()
+
+        let outBytes = stdoutTask.GetAwaiter().GetResult()
+        let errBytes = stderrTask.GetAwaiter().GetResult()
+        let out = decodeProcessOutput outBytes
+        let err = decodeProcessOutput errBytes
 
         let exitCode = if exited then proc.ExitCode else -1
         let logFile = writeLog ("setup-" :: commandArgs) out err
@@ -588,7 +646,15 @@ module Harness =
 
     // Command arg sets covering all exposed features (expandable)
     let downloadArgs () =
-        [ "download"; "--spec"; dataspec; "--option"; openOption; "--from"; fromTime ]
+        [ "download"
+          "--spec"
+          dataspec
+          "--option"
+          openOption
+          "--from"
+          fromTime
+          "--max-records"
+          "30" ]
 
     let downloadPersistArgs () =
         [ "download"
@@ -598,6 +664,8 @@ module Harness =
           openOption
           "--from"
           fromTime
+          "--max-records"
+          "30"
           "--output"
           Path.Combine(savePath, "persist") ]
 
@@ -709,8 +777,8 @@ type CliTests(output: ITestOutputHelper, fixture: ServiceKeySetupFixture) =
             if hasCom then
                 // Real COM mode - should not have stub payloads
                 Assert.DoesNotContain("Stub payload", stdout)
+            // COM fallback to Stub - should have stub payloads
             else if hasStub && hasComFallback then
-                // COM fallback to Stub - should have stub payloads
                 Assert.Contains("Stub payload", stdout)
             else
                 Assert.Fail(

--- a/tests/Xanthos.Cli.E2E/README.md
+++ b/tests/Xanthos.Cli.E2E/README.md
@@ -12,7 +12,7 @@ End-to-end test project that runs `samples/Xanthos.Cli` via `dotnet run` and ver
 |----------|-------|----------|
 | Basic | 5 | `version`, `download`, `set-save-flag`, `help` |
 | Realtime | 1 | `realtime` |
-| Config Round-trip | 5 | `get/set-save-flag`, `get/set-save-path`, `get/set-service-key`, `get/set-payoff-dialog`, `get/set-parent-hwnd` |
+| Config | 5 | `get/set-save-flag`, `get/set-save-path`, `get-service-key`, `get-payoff-dialog`, `set-parent-hwnd` |
 | Course Diagram | 2 | `course-file`, `course-file2` |
 | Silks | 2 | `silks-file`, `silks-binary` |
 | Movie | 5 | `movie-check`, `movie-check-with-type`, `movie-play`, `movie-play-with-type`, `movie-open` |
@@ -32,6 +32,10 @@ End-to-end test project that runs `samples/Xanthos.Cli` via `dotnet run` and ver
 |------|-------------|------------|
 | Stub (default) | Runs CLI with `--stub` to verify command structure without COM | `dotnet test tests/Xanthos.Cli.E2E` |
 | COM | Runs on Windows with real JV-Link installation | Set `XANTHOS_E2E_MODE=COM` and required env vars |
+
+> **Note:** Some configuration commands are not fully round-trippable in COM mode due to JV-Link limitations:
+> - `ParentHWnd` is write-only (so `get-parent-hwnd` is not supported)
+> - `m_payflag` is read-only (so `set-payoff-dialog` is not supported)
 
 ## Environment Variables
 

--- a/tests/Xanthos.Cli.E2E/Xanthos.Cli.E2E.fsproj
+++ b/tests/Xanthos.Cli.E2E/Xanthos.Cli.E2E.fsproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Xanthos.PropertyTests/Xanthos.PropertyTests.fsproj
+++ b/tests/Xanthos.PropertyTests/Xanthos.PropertyTests.fsproj
@@ -8,7 +8,7 @@
     <PackageReference Include="FsCheck" Version="3.3.2" />
     <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Xanthos.UnitTests/ComContractTests.fs
+++ b/tests/Xanthos.UnitTests/ComContractTests.fs
@@ -458,10 +458,10 @@ let ``SavePath property should be readable via SetSavePathDirect`` () =
     Assert.Equal("C:\\test\\path", client.SavePath)
 
 [<Fact>]
-let ``ServiceKey property should be readable and writable`` () =
+let ``ServiceKey property should be readable via SetServiceKeyDirect`` () =
     let stub = new JvLinkStub()
     let client = stub :> IJvLinkClient
-    client.ServiceKey <- "test-key-123"
+    client.SetServiceKeyDirect "test-key-123" |> ignore
     Assert.Equal("test-key-123", client.ServiceKey)
 
 [<Fact>]

--- a/tests/Xanthos.UnitTests/CoreModuleTests.fs
+++ b/tests/Xanthos.UnitTests/CoreModuleTests.fs
@@ -789,6 +789,57 @@ module TextModuleTests =
         Assert.NotNull(result)
 
     [<Fact>]
+    let ``decodeShiftJisBstrBytesIfNeeded should keep already-decoded Japanese text`` () =
+        let text = "東京芝/芝1200m"
+        let result = decodeShiftJisBstrBytesIfNeeded text
+        Assert.Equal(text, result)
+
+    [<Fact>]
+    let ``decodeShiftJisBstrBytesIfNeeded should decode low-byte-per-char Shift-JIS stuffing`` () =
+        let expected = "東京芝/芝1200m"
+        let bytes = System.Text.Encoding.GetEncoding(932).GetBytes(expected)
+        let stuffed = bytes |> Array.map char |> (fun chars -> new string (chars))
+        let result = decodeShiftJisBstrBytesIfNeeded stuffed
+        Assert.Equal(expected, result)
+
+    [<Fact>]
+    let ``decodeShiftJisBstrBytesIfNeeded should stop at NUL terminator`` () =
+        let expected = "東京芝/芝1200m"
+        let bytes = System.Text.Encoding.GetEncoding(932).GetBytes(expected)
+        let stuffedBytes = Array.concat [ bytes; [| 0uy; 0x80uy; 0xFFuy; 0uy |] ]
+        let stuffed = stuffedBytes |> Array.map char |> (fun chars -> new string (chars))
+        let result = decodeShiftJisBstrBytesIfNeeded stuffed
+        Assert.Equal(expected, result)
+
+    [<Fact>]
+    let ``decodeShiftJisBstrBytesIfNeeded should decode raw Shift-JIS bytes copied into UTF-16 buffer`` () =
+        let expected = "東京芝/芝1200m"
+        let bytes = System.Text.Encoding.GetEncoding(932).GetBytes(expected)
+
+        let padded =
+            if bytes.Length % 2 = 0 then
+                bytes
+            else
+                Array.append bytes [| 0uy |]
+
+        let stuffed = System.Text.Encoding.Unicode.GetString(padded)
+        let result = decodeShiftJisBstrBytesIfNeeded stuffed
+        Assert.Equal(expected, result)
+
+    [<Fact>]
+    let ``decodeShiftJisBstrBytesIfNeeded should decode high-byte-per-char Shift-JIS stuffing`` () =
+        let expected = "東京芝/芝1200m"
+        let bytes = System.Text.Encoding.GetEncoding(932).GetBytes(expected)
+
+        let stuffed =
+            bytes
+            |> Array.map (fun b -> char (int b <<< 8))
+            |> fun chars -> new string (chars)
+
+        let result = decodeShiftJisBstrBytesIfNeeded stuffed
+        Assert.Equal(expected, result)
+
+    [<Fact>]
     let ``encodeShiftJis should encode valid text`` () =
         let result = encodeShiftJis "テスト"
         let decoded = System.Text.Encoding.GetEncoding(932).GetString(result)
@@ -1226,3 +1277,23 @@ module TextBranchCoverageTests =
         let mixed = "\uFF10\uFF21\uFF41テスト" // 0, A, a, テスト
         let result = normalizeJvText mixed
         Assert.Equal("0Aaテスト", result)
+
+    [<Fact>]
+    let ``decodeShiftJis with truncated Shift-JIS 2-byte char uses lenient fallback`` () =
+        // Encode a Shift-JIS string then chop off the last byte of a 2-byte character.
+        // Lenient Shift-JIS should decode the leading valid characters without U+FFFD.
+        let enc = System.Text.Encoding.GetEncoding(932)
+        let fullBytes = enc.GetBytes("タイキシャトル")
+        // Drop the last byte to simulate a mid-character truncation
+        let truncated = fullBytes.[0 .. fullBytes.Length - 2]
+        let result = decodeShiftJis truncated
+        // The valid leading characters should be present and no U+FFFD replacement chars
+        Assert.True(result.Contains("タイキシャト"), $"Expected leading chars present, got: {result}")
+        Assert.False(result.Contains("\uFFFD"), $"Should not contain U+FFFD, got: {result}")
+
+    [<Fact>]
+    let ``decodeShiftJis with lone invalid byte 0x80 uses lenient Shift-JIS fallback`` () =
+        // 0x80 is invalid as a standalone byte in strict Shift-JIS.
+        // Lenient Shift-JIS (code page 932) maps it to a character without producing U+FFFD.
+        let result = decodeShiftJis [| 0x80uy |]
+        Assert.False(result.Contains("\uFFFD"), $"Should not contain U+FFFD, got: {result}")

--- a/tests/Xanthos.UnitTests/FixtureParserTests.fs
+++ b/tests/Xanthos.UnitTests/FixtureParserTests.fs
@@ -161,7 +161,7 @@ module KnownRecordTypes =
 ///     --sid YOUR_SID capture-fixtures \
 ///     --output tests/fixtures \
 ///     --specs "RACE,DIFF" \
-///     --from "2024-01-01" \
+///     --from "20240101" \
 ///     --max-records 5
 /// </summary>
 type FixtureParserTests() =

--- a/tests/Xanthos.UnitTests/JvLinkServiceErrorTests.fs
+++ b/tests/Xanthos.UnitTests/JvLinkServiceErrorTests.fs
@@ -66,9 +66,7 @@ let private createStubThatFailsInit () =
 
         member _.SavePath = ""
 
-        member _.ServiceKey
-            with get () = ""
-            and set (_) = ()
+        member _.ServiceKey = ""
 
         member _.TryGetSaveFlag() = Ok false
         member _.TryGetSavePath() = Ok ""
@@ -134,9 +132,7 @@ let private createStubThatFailsOpen () =
 
         member _.SavePath = ""
 
-        member _.ServiceKey
-            with get () = ""
-            and set (_) = ()
+        member _.ServiceKey = ""
 
         member _.TryGetSaveFlag() = Ok false
         member _.TryGetSavePath() = Ok ""

--- a/tests/Xanthos.UnitTests/PropertyTests.fs
+++ b/tests/Xanthos.UnitTests/PropertyTests.fs
@@ -159,12 +159,15 @@ let ``parseCode SexCode accepts valid codes`` () =
 
 [<Property>]
 let ``parseCode SexCode rejects invalid codes`` (code: string) =
-    let validCodes = [ "1"; "2"; "3" ]
-
-    if List.contains code validCodes then
-        true // Valid codes are tested separately
-    else
-        parseCode<SexCode> code = None
+    match parseCode<SexCode> code with
+    | Some parsed ->
+        // If parsing succeeds, the result must be a defined enum value
+        Enum.IsDefined(typeof<SexCode>, parsed)
+    | None ->
+        // If parsing fails, the code must not be parseable as a valid enum int
+        match Int32.TryParse code with
+        | true, n -> not (Enum.IsDefined(typeof<SexCode>, n))
+        | false, _ -> true
 
 [<Property>]
 let ``parseCode RacecourseCode accepts valid numeric codes`` () =

--- a/tests/Xanthos.UnitTests/PropertyTests.fs
+++ b/tests/Xanthos.UnitTests/PropertyTests.fs
@@ -2,6 +2,7 @@ module Xanthos.UnitTests.PropertyTests
 
 open System
 open FsCheck
+open FsCheck.FSharp
 open FsCheck.Xunit
 open Xanthos.Core
 open Xanthos.Core.Text
@@ -40,8 +41,10 @@ let horseIdGen =
     }
 
 /// Generate valid byte arrays with specific size
+let private defaults = ArbMap.defaults
+
 let byteArrayGen size =
-    Gen.arrayOfLength size Arb.generate<byte>
+    Gen.arrayOfLength size (ArbMap.generate<byte> defaults)
 
 // ============================================================================
 // Property-Based Tests for RecordParser Core Functions

--- a/tests/Xanthos.UnitTests/Tests.fs
+++ b/tests/Xanthos.UnitTests/Tests.fs
@@ -569,7 +569,7 @@ let ``All IJvLinkClient properties read and write correctly`` () =
     stubClient.SetSavePathDirect "C:\\temp\\jvdata" |> ignore
     Assert.Equal("C:\\temp\\jvdata", stubClient.SavePath)
 
-    stubClient.ServiceKey <- "TESTKEY123456789"
+    stubClient.SetServiceKeyDirect "TESTKEY123456789" |> ignore
     Assert.Equal("TESTKEY123456789", stubClient.ServiceKey)
 
     let version = stubClient.JVLinkVersion

--- a/tests/Xanthos.UnitTests/Tests.fs
+++ b/tests/Xanthos.UnitTests/Tests.fs
@@ -427,6 +427,25 @@ let ``Course diagram retrieval returns stubbed values`` () =
     | Error err -> failwithf "CourseDiagramBasic error %A" err
 
 [<Fact>]
+let ``Course diagram garbled explanation is suppressed`` () =
+    let stubClient = new JvLinkStub(Seq.empty)
+    let garbled = String(char 0xE000, 20) // Private-use chars should be treated as unreadable
+    stubClient.ConfigureCourseFileResponse("C:\\course.gif", garbled)
+
+    let config =
+        match JvLinkConfig.create "SID" None None None with
+        | Ok cfg -> cfg
+        | Error err -> failwithf "unexpected config error %A" err
+
+    let service = new JvLinkService(stubClient :> IJvLinkClient, config)
+
+    match service.GetCourseDiagram("9999999905240011") with
+    | Ok diagram ->
+        Assert.Equal("C:\\course.gif", diagram.FilePath)
+        Assert.Equal<string option>(None, diagram.Explanation)
+    | Error err -> failwithf "CourseDiagram error %A" err
+
+[<Fact>]
 let ``Silks file generation returns requested path`` () =
     let stubClient = new JvLinkStub(Seq.empty)
     let mutable receivedPattern = None
@@ -773,11 +792,14 @@ let ``decodeShiftJis converts bytes to unicode`` () =
     Assert.Equal(source, decoded)
 
 [<Fact>]
-let ``decodeShiftJis falls back to utf8`` () =
+let ``decodeShiftJis prefers lenient Shift-JIS over UTF-8 fallback`` () =
+    // UTF-8 bytes of Japanese text are valid Shift-JIS multi-byte sequences,
+    // so lenient Shift-JIS decoding takes priority and produces different output.
     let source = "カタカナ123"
     let bytes = Encoding.UTF8.GetBytes(source)
     let decoded = Text.decodeShiftJis bytes
-    Assert.Equal(source, decoded)
+    // Should not throw and should return non-empty output
+    Assert.False(String.IsNullOrEmpty decoded)
 
 [<Fact>]
 let ``normalizeJvText expands half-width katakana and digits`` () =

--- a/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
+++ b/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
@@ -15,8 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="FsCheck" Version="2.16.6" />
-    <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
+    <PackageReference Include="FsCheck" Version="3.3.2" />
+    <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 

--- a/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
+++ b/tests/Xanthos.UnitTests/Xanthos.UnitTests.fsproj
@@ -5,19 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="FsCheck" Version="2.16.6" />
     <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Merge `develop` into `main` for the v0.2.0 release.

### Breaking Changes

- Make `IJvLinkClient.SavePath` property read-only (#1, #4)
- Make `IJvLinkClient.ServiceKey` property read-only (#5)
- Default to JVGets; opt out via `XANTHOS_USE_JVREAD=1` (#3)

### Fixed

- Reduce excessive diagnostic logging in `checkUseJvGets()` (#2)
- Avoid unsupported COM property access for `ParentHWnd` / `m_payflag` (#14)
- Improve CLI E2E harness diagnostics for exe-mode builds (#17)
- Fix CLI mojibake for Japanese text when stdout is redirected (#19)

### Internal (not in CHANGELOG)

- Update dependencies to latest stable versions (#22)
- Migrate UnitTests FsCheck v2 → v3 (#23)
- Add branch naming convention, merge strategy docs (#13, #16)
- E2E silks-file output directory fix (#11)

## Post-merge steps

1. Create and push tag `v0.2.0` (triggers Release workflow → NuGet publish)
2. Close #3

## Merge strategy

Use **merge commit** per CONTRIBUTING.md guidelines.