### PR TITLE
fix(test): correct parseCode SexCode property test

### DIFF
--- a/tests/Xanthos.UnitTests/PropertyTests.fs
+++ b/tests/Xanthos.UnitTests/PropertyTests.fs
@@ -159,12 +159,15 @@ let ``parseCode SexCode accepts valid codes`` () =
 
 [<Property>]
 let ``parseCode SexCode rejects invalid codes`` (code: string) =
-    let validCodes = [ "1"; "2"; "3" ]
-
-    if List.contains code validCodes then
-        true // Valid codes are tested separately
-    else
-        parseCode<SexCode> code = None
+    match parseCode<SexCode> code with
+    | Some parsed ->
+        // If parsing succeeds, the result must be a defined enum value
+        Enum.IsDefined(typeof<SexCode>, parsed)
+    | None ->
+        // If parsing fails, the code must not be parseable as a valid enum int
+        match Int32.TryParse code with
+        | true, n -> not (Enum.IsDefined(typeof<SexCode>, n))
+        | false, _ -> true
 
 [<Property>]
 let ``parseCode RacecourseCode accepts valid numeric codes`` () =


### PR DESCRIPTION
## Summary

Fix flaky `parseCode SexCode rejects invalid codes` property test exposed by FsCheck v3 on macOS CI.

## Root cause

The test hardcoded `["1"; "2"; "3"]` as the only valid inputs. However, `parseCode` uses `Int32.TryParse`, so strings like `"02"` parse to `2` (a valid `SexCode.Female`). FsCheck v3's different random generation produced `"02"`, causing the assertion to fail.

## Fix

Replace the allowlist check with a round-trip validation:
- If `parseCode` returns `Some`, verify the result is a defined enum value
- If `parseCode` returns `None`, verify the input cannot be parsed to a valid enum int

## Test plan

- [x] `dotnet build` succeeds
- [x] `parseCode SexCode` tests pass (2/2)