### PR TITLE
docs: fix stale references after v0.2.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This document explains how to contribute to the project.
 
 ### Prerequisites
 
-- .NET 10 SDK (preview)
+- .NET 10 SDK
 - Git
 
 ### Using Nix (Recommended)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ open Xanthos.Runtime
 open Xanthos.Interop
 
 // Create configuration
+// UseJvGets = None defaults to true (JVGets mode).
+// Set to Some false to use JVRead instead, or set XANTHOS_USE_JVREAD=1.
 let config =
     { Sid = "YOUR_SID"
       SavePath = Some @"C:\JVData"


### PR DESCRIPTION
## Summary

- Remove "(preview)" from .NET 10 SDK prerequisite in CONTRIBUTING.md (.NET 10 is GA)
- Clarify that `UseJvGets = None` defaults to JVGets mode in README quick-start example